### PR TITLE
Run tfgen after pulumi-terraform update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,7 +61,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:28d643e5dedba6b2c4d8b954fb60d4004cf1a097baa01d3645f7b958fc706fd3"
+  digest = "1:b4dd9ed9eabe3c73796010798cab7632f73ee46695f1bdb71a07a8dce71a1ac3"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -103,8 +103,8 @@
     "service/sts",
   ]
   pruneopts = ""
-  revision = "81f3829f5a9d041041bdf56e55926691309d7699"
-  version = "v1.16.26"
+  revision = "503020bbd95ec9f25b061a83aa62567bc43e6d96"
+  version = "v1.16.32"
 
 [[projects]]
   branch = "master"
@@ -199,12 +199,12 @@
   revision = "ac2f73035d72e74d6032da5ec7cfcce965db0f65"
 
 [[projects]]
-  digest = "1:e988ed0ca0d81f4d28772760c02ee95084961311291bdfefc1b04617c178b722"
+  digest = "1:c9bebdae4ac52d0c3bbe5876de3d72f3bb05b4986865cdb3f15e305e1dc4fbca"
   name = "github.com/fatih/color"
   packages = ["."]
   pruneopts = ""
-  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
-  version = "v1.7.0"
+  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
@@ -285,15 +285,15 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:cda0c129f2cb3fc4a0ce5dc5a1b50db4812313850c274d439b9c130107116dea"
+  digest = "1:695d10d3138f7c1d07d048c37e0456e9737dfd599cdf7892c2e64ad7ac45cd74"
   name = "github.com/hashicorp/go-getter"
   packages = [
     ".",
     "helper/url",
   ]
   pruneopts = ""
-  revision = "dde89f93975670ed3a449be055954c139e36810f"
-  version = "v1.0.1"
+  revision = "062101f97c304b1bd56c0dc1aa9f06574ce69d66"
+  version = "v1.0.3"
 
 [[projects]]
   digest = "1:72308fdd6d5ef61106a95be7ca72349a5565809042b6426a3cfb61d99483b824"
@@ -363,7 +363,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bd3a2c753b16511930b193d7b730ad294550a622fb53219418090b3929c0786e"
+  digest = "1:4eb9db980e91c9eb535317f6bf269878a088537a1f76c0cd15734d70d0744993"
   name = "github.com/hashicorp/hil"
   packages = [
     ".",
@@ -372,7 +372,7 @@
     "scanner",
   ]
   pruneopts = ""
-  revision = "59d7c1fee952b29ee4c9ceba65c9d02ee28eb281"
+  revision = "97b3a9cdfa9349086cfad7ea2fe3165bfe3cbf63"
 
 [[projects]]
   digest = "1:51430c345f48c781f7f43146b574ec498c62c608bfff3715fef4c915d96ed4fc"
@@ -461,12 +461,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
+  digest = "1:0f79867e9aac8a4e20bc1b0956d81f340da9ade9bcc00a4bfb1ebd738c152f7a"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   pruneopts = ""
-  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
-  version = "v0.0.9"
+  revision = "efa589957cd060542a26d2dd7832fd6a6c6c3ade"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:3140e04675a6a91d2a20ea9d10bdadf6072085502e6def6768361260aee4b967"
@@ -607,7 +607,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:95452e7f7d8f2d0e8ece6be0f4ea670aa97e1cc7b405c228850941d4095bca98"
+  digest = "1:7e1a87d241a65e6c8e2eff493d4e1862f2899efdb6ae4b62cfdf7b26a4cfecc5"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/apitype",
@@ -654,18 +654,18 @@
     "sdk/proto/go",
   ]
   pruneopts = ""
-  revision = "c974bff8e084f7a7d26f4251e697b04540b9e1d0"
+  revision = "06d3c7811faade425ef5b087fd855fd767237af1"
 
 [[projects]]
   branch = "master"
-  digest = "1:f5724e01a1c46cd007d5a7f8ac0acf446274517847dd92f4979eea703dd431c5"
+  digest = "1:ee977962b3fd8565483e1114262993016dcec9f170447a86b690b08ad5ab5bde"
   name = "github.com/pulumi/pulumi-terraform"
   packages = [
     "pkg/tfbridge",
     "pkg/tfgen",
   ]
   pruneopts = ""
-  revision = "eccabee0f2dfd7f9172e0a73288836493ee96078"
+  revision = "50c3039457f71c1bbc62f0acd86e0f8ed72e2cea"
 
 [[projects]]
   branch = "master"
@@ -820,7 +820,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cbc1ebc01ec2ceb2c3cc7b9e33357dbc3eff173335f02d9f01603f14102602a7"
+  digest = "1:5462386895a322b94a79a5de7314310edbd5f4d15f851ae032f146b2c951b3de"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -845,11 +845,11 @@
     "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "b8fe1690c61389d7d2a8074a507d1d40c5d30448"
+  revision = "74369b46fc6756741c016591724fd1cb8e26845f"
 
 [[projects]]
   branch = "master"
-  digest = "1:1e9704e5379e68ac473c28aeb3f7e7cd4036ae8a246bf0285b5ebdbb8e0cfacf"
+  digest = "1:1d52dac9bdc355f83ad9916bc657baa7d8735a108ae749da8e8d3513a1b15f28"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -863,18 +863,18 @@
     "trace",
   ]
   pruneopts = ""
-  revision = "d26f9f9a57f3fab6a695bec0d84433c2c50f8bbf"
+  revision = "65e2d4e15006aab9813ff8769e768bbf4bb667a0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4d6f20f5bc52af99569b1be5ea55d4e22646d5e022b92f2d3d75347628614734"
+  digest = "1:c05d7df4515a5ade109706194fbda5cfd23c1754b26e17b012281c2d247c01d9"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "afcc84fd7533758f95a6e93ae710aa945a0b7e73"
+  revision = "3b5209105503162ded1863c307ac66fec31120dd"
 
 [[projects]]
   digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"

--- a/resources.go
+++ b/resources.go
@@ -97,7 +97,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi": "latest",
+				"@pulumi/pulumi": "^0.16.14",
 			},
 			DevDependencies: map[string]string{
 				"@types/node": "^8.0.25", // so we can access strongly typed node definitions.
@@ -105,7 +105,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		Python: &tfbridge.PythonInfo{
 			Requires: map[string]string{
-				"pulumi": ">=0.16.0,<0.17.0",
+				"pulumi": ">=0.16.14,<0.17.0",
 			},
 		},
 	}

--- a/sdk/nodejs/cm/device.ts
+++ b/sdk/nodejs/cm/device.ts
@@ -15,11 +15,10 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_cm_device_my_new_device = new f5bigip.cm.Device("my_new_device", {
+ * const myNewDevice = new f5bigip.cm.Device("my_new_device", {
  *     configsyncIp: "2.2.2.2",
  *     mirrorIp: "10.10.10.10",
  *     mirrorSecondaryIp: "11.11.11.11",
- *     name: "bigip300.f5.com",
  * });
  * ```
  */

--- a/sdk/nodejs/cm/deviceGroup.ts
+++ b/sdk/nodejs/cm/deviceGroup.ts
@@ -15,7 +15,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_cm_devicegroup_my_new_devicegroup = new f5bigip.cm.DeviceGroup("my_new_devicegroup", {
+ * const myNewDevicegroup = new f5bigip.cm.DeviceGroup("my_new_devicegroup", {
  *     autoSync: "enabled",
  *     devices: [
  *         {
@@ -26,7 +26,6 @@ import * as utilities from "../utilities";
  *         },
  *     ],
  *     fullLoadOnSync: "true",
- *     name: "sanjose_devicegroup",
  *     type: "sync-only",
  * });
  * ```

--- a/sdk/nodejs/ltm/dataGroup.ts
+++ b/sdk/nodejs/ltm/dataGroup.ts
@@ -17,8 +17,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_datagroup_datagroup = new f5bigip.ltm.DataGroup("datagroup", {
- *     name: "/Common/dgx2",
+ * const datagroup = new f5bigip.ltm.DataGroup("datagroup", {
  *     records: [
  *         {
  *             data: "pool1",

--- a/sdk/nodejs/ltm/monitor.ts
+++ b/sdk/nodejs/ltm/monitor.ts
@@ -16,13 +16,12 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_monitor_monitor = new f5bigip.ltm.Monitor("monitor", {
+ * const monitor = new f5bigip.ltm.Monitor("monitor", {
  *     destination: "1.2.3.4:1234",
- *     interval: Number.parseFloat("999"),
- *     name: "/Common/terraform_monitor",
+ *     interval: 999,
  *     parent: "/Common/http",
  *     send: "GET /some/path\n",
- *     timeout: Number.parseFloat("999"),
+ *     timeout: 999,
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/node.ts
+++ b/sdk/nodejs/ltm/node.ts
@@ -17,9 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_node_node = new f5bigip.ltm.Node("node", {
+ * const node = new f5bigip.ltm.Node("node", {
  *     address: "10.10.10.10",
- *     name: "/Common/terraform_node1",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/persistenceProfileCookie.ts
+++ b/sdk/nodejs/ltm/persistenceProfileCookie.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_persistence_profile_cookie_test_ppcookie = new f5bigip.ltm.PersistenceProfileCookie("test_ppcookie", {
+ * const testPpcookie = new f5bigip.ltm.PersistenceProfileCookie("test_ppcookie", {
  *     alwaysSend: "enabled",
  *     cookieEncryption: "required",
  *     cookieEncryptionPassphrase: "iam",
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  *     matchAcrossPools: "enabled",
  *     matchAcrossServices: "enabled",
  *     matchAcrossVirtuals: "enabled",
- *     name: "/Common/terraform_cookie",
  *     overrideConnLimit: "enabled",
  *     timeout: 3600,
  * });

--- a/sdk/nodejs/ltm/persistenceProfileDstAddr.ts
+++ b/sdk/nodejs/ltm/persistenceProfileDstAddr.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_persistence_profile_dstaddr_dstaddr = new f5bigip.ltm.PersistenceProfileDstAddr("dstaddr", {
+ * const dstaddr = new f5bigip.ltm.PersistenceProfileDstAddr("dstaddr", {
  *     defaultsFrom: "/Common/dest_addr",
  *     hashAlgorithm: "carp",
  *     mask: "255.255.255.255",
@@ -21,7 +21,6 @@ import * as utilities from "../utilities";
  *     matchAcrossServices: "enabled",
  *     matchAcrossVirtuals: "enabled",
  *     mirror: "enabled",
- *     name: "/Common/terraform_ppdstaddr",
  *     overrideConnLimit: "enabled",
  *     timeout: 3600,
  * });

--- a/sdk/nodejs/ltm/persistenceProfileSrcAddr.ts
+++ b/sdk/nodejs/ltm/persistenceProfileSrcAddr.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_persistence_profile_srcaddr_srcaddr = new f5bigip.ltm.PersistenceProfileSrcAddr("srcaddr", {
+ * const srcaddr = new f5bigip.ltm.PersistenceProfileSrcAddr("srcaddr", {
  *     defaultsFrom: "/Common/source_addr",
  *     hashAlgorithm: "carp",
  *     mapProxies: "enabled",
@@ -22,7 +22,6 @@ import * as utilities from "../utilities";
  *     matchAcrossServices: "enabled",
  *     matchAcrossVirtuals: "enabled",
  *     mirror: "enabled",
- *     name: "/Common/terraform_srcaddr",
  *     overrideConnLimit: "enabled",
  *     timeout: 3600,
  * });

--- a/sdk/nodejs/ltm/persistenceProfileSsl.ts
+++ b/sdk/nodejs/ltm/persistenceProfileSsl.ts
@@ -13,13 +13,12 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_persistence_profile_ssl_ppssl = new f5bigip.ltm.PersistenceProfileSsl("ppssl", {
+ * const ppssl = new f5bigip.ltm.PersistenceProfileSsl("ppssl", {
  *     defaultsFrom: "/Common/ssl",
  *     matchAcrossPools: "enabled",
  *     matchAcrossServices: "enabled",
  *     matchAcrossVirtuals: "enabled",
  *     mirror: "enabled",
- *     name: "/Common/terraform_ssl",
  *     overrideConnLimit: "enabled",
  *     timeout: 3600,
  * });

--- a/sdk/nodejs/ltm/pool.ts
+++ b/sdk/nodejs/ltm/pool.ts
@@ -17,7 +17,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_pool_pool = new f5bigip.ltm.Pool("pool", {
+ * const pool = new f5bigip.ltm.Pool("pool", {
  *     allowNat: "yes",
  *     allowSnat: "yes",
  *     loadBalancingMode: "round-robin",
@@ -25,7 +25,6 @@ import * as utilities from "../utilities";
  *         bigip_ltm_monitor_monitor.name,
  *         bigip_ltm_monitor_monitor2.name,
  *     ],
- *     name: "/Common/terraform-pool",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/poolAttachment.ts
+++ b/sdk/nodejs/ltm/poolAttachment.ts
@@ -17,8 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_pool_attachment_node_terraform_pool = new f5bigip.ltm.PoolAttachment("node-terraform_pool", {
- *     node: bigip_ltm_node_node.name.apply(__arg0 => `${__arg0%!v(PANIC=interface conversion: il.Node is nil, not *il.ResourceNode)}:80`),
+ * const node_terraform_pool = new f5bigip.ltm.PoolAttachment("node-terraform_pool", {
+ *     node: bigip_ltm_node_node.name.apply(name => `${name}:80`),
  *     pool: "/Common/terraform-pool",
  * });
  * ```

--- a/sdk/nodejs/ltm/profileFastHttp.ts
+++ b/sdk/nodejs/ltm/profileFastHttp.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_fasthttp_sjfasthttpprofile = new f5bigip.ltm.ProfileFastHttp("sjfasthttpprofile", {
+ * const sjfasthttpprofile = new f5bigip.ltm.ProfileFastHttp("sjfasthttpprofile", {
  *     connpoolMaxreuse: 2,
  *     connpoolMaxsize: 2048,
  *     connpoolMinsize: 0,
@@ -27,7 +27,6 @@ import * as utilities from "../utilities";
  *     forcehttp10response: "disabled",
  *     idleTimeout: 300,
  *     maxheaderSize: 32768,
- *     name: "sjfasthttpprofile",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/profileFastL4.ts
+++ b/sdk/nodejs/ltm/profileFastL4.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_fastl4_profile_fastl4 = new f5bigip.ltm.ProfileFastL4("profile_fastl4", {
+ * const profileFastl4 = new f5bigip.ltm.ProfileFastL4("profile_fastl4", {
  *     clientTimeout: 40,
  *     defaultsFrom: "/Common/fastL4",
  *     explicitflowMigration: "enabled",
@@ -24,8 +24,7 @@ import * as utilities from "../utilities";
  *     idleTimeout: "200",
  *     iptosToclient: "pass-through",
  *     iptosToserver: "pass-through",
- *     keepaliveInterval: "disabled",
- *     name: "/Common/sjfastl4profile",
+ *     keepaliveInterval: "disabled", //This cannot take enabled
  *     partition: "Common",
  * });
  * ```

--- a/sdk/nodejs/ltm/profileHttp2.ts
+++ b/sdk/nodejs/ltm/profileHttp2.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_http2_nyhttp2 = new f5bigip.ltm.ProfileHttp2("nyhttp2", {
+ * const nyhttp2 = new f5bigip.ltm.ProfileHttp2("nyhttp2", {
  *     activationModes: [
  *         "alpn",
  *         "npn",
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  *     concurrentStreamsPerConnection: 10,
  *     connectionIdleTimeout: 30,
  *     defaultsFrom: "/Common/http2",
- *     name: "/Common/NewYork_http2",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/profileHttpCompress.ts
+++ b/sdk/nodejs/ltm/profileHttpCompress.ts
@@ -17,9 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_httpcompress_sjhttpcompression = new f5bigip.ltm.ProfileHttpCompress("sjhttpcompression", {
+ * const sjhttpcompression = new f5bigip.ltm.ProfileHttpCompress("sjhttpcompression", {
  *     defaultsFrom: "/Common/httpcompression",
- *     name: "/Common/sjhttpcompression2",
  *     uriExcludes: [
  *         "www.abc.f5.com",
  *         "www.abc2.f5.com",

--- a/sdk/nodejs/ltm/profileOneConnect.ts
+++ b/sdk/nodejs/ltm/profileOneConnect.ts
@@ -16,13 +16,12 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_oneconnect_oneconnect_sanjose = new f5bigip.ltm.ProfileOneConnect("oneconnect-sanjose", {
+ * const oneconnect_sanjose = new f5bigip.ltm.ProfileOneConnect("oneconnect-sanjose", {
  *     defaultsFrom: "/Common/oneconnect",
  *     idleTimeoutOverride: "disabled",
  *     maxAge: 3600,
  *     maxReuse: 1000,
  *     maxSize: 1000,
- *     name: "sanjose",
  *     partition: "Common",
  *     sharePools: "disabled",
  *     sourceMask: "255.255.255.255",

--- a/sdk/nodejs/ltm/profileTcp.ts
+++ b/sdk/nodejs/ltm/profileTcp.ts
@@ -16,7 +16,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_profile_tcp_sanjose_tcp_lan_profile = new f5bigip.ltm.ProfileTcp("sanjose-tcp-lan-profile", {
+ * const sanjose_tcp_lan_profile = new f5bigip.ltm.ProfileTcp("sanjose-tcp-lan-profile", {
  *     closeWaitTimeout: 5,
  *     deferredAccept: "enabled",
  *     fastOpen: "enabled",
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  *     finwaitTimeout: 300,
  *     idleTimeout: 200,
  *     keepaliveInterval: 1700,
- *     name: "sanjose-tcp-lan-profile",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/snat.ts
+++ b/sdk/nodejs/ltm/snat.ts
@@ -17,9 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_snat_snat3 = new f5bigip.ltm.Snat("snat3", {
+ * const snat3 = new f5bigip.ltm.Snat("snat3", {
  *     mirror: "false",
- *     name: "snat3",
  *     origins: ["6.1.6.6"],
  *     snatpool: "/Common/sanjaysnatpool",
  * });

--- a/sdk/nodejs/ltm/snatPool.ts
+++ b/sdk/nodejs/ltm/snatPool.ts
@@ -17,12 +17,11 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_snatpoolpool_snatpool_sanjose = new f5bigip.LtmSnatpoolpool("snatpool_sanjose", {
+ * const snatpoolSanjose = new f5bigip.LtmSnatpoolpool("snatpool_sanjose", {
  *     members: [
  *         "191.1.1.1",
  *         "194.2.2.2",
  *     ],
- *     name: "/Common/snatpool_sanjose",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/virtualAddress.ts
+++ b/sdk/nodejs/ltm/virtualAddress.ts
@@ -17,9 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_virtual_address_vs_va = new f5bigip.ltm.VirtualAddress("vs_va", {
+ * const vsVa = new f5bigip.ltm.VirtualAddress("vs_va", {
  *     advertizeRoute: true,
- *     name: "/Common/vs_va",
  * });
  * ```
  */

--- a/sdk/nodejs/ltm/virtualServer.ts
+++ b/sdk/nodejs/ltm/virtualServer.ts
@@ -17,16 +17,15 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_virtual_server_http = new f5bigip.ltm.VirtualServer("http", {
+ * const http = new f5bigip.ltm.VirtualServer("http", {
  *     destination: "10.12.12.12",
- *     name: "/Common/terraform_vs_http",
  *     pool: "/Common/the-default-pool",
  *     port: 80,
  * });
- * const bigip_ltm_virtual_server_https = new f5bigip.ltm.VirtualServer("https", {
+ * // A Virtual server with separate client and server profiles
+ * const https = new f5bigip.ltm.VirtualServer("https", {
  *     clientProfiles: ["/Common/clientssl"],
  *     destination: "10.255.255.254",
- *     name: "/Common/terraform_vs_https",
  *     port: 443,
  *     serverProfiles: ["/Common/serverssl"],
  *     sourceAddressTranslation: "automap",

--- a/sdk/nodejs/net/route.ts
+++ b/sdk/nodejs/net/route.ts
@@ -17,9 +17,8 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_net_route_route2 = new f5bigip.net.Route("route2", {
+ * const route2 = new f5bigip.net.Route("route2", {
  *     gw: "1.1.1.2",
- *     name: "external-route",
  *     network: "10.10.10.0/24",
  * });
  * ```

--- a/sdk/nodejs/net/vlan.ts
+++ b/sdk/nodejs/net/vlan.ts
@@ -17,12 +17,11 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_net_vlan_vlan1 = new f5bigip.net.Vlan("vlan1", {
+ * const vlan1 = new f5bigip.net.Vlan("vlan1", {
  *     interfaces: [{
  *         tagged: false,
- *         vlanport: "1.200000",
+ *         vlanport: "1.2",
  *     }],
- *     name: "/Common/Internal",
  *     tag: 101,
  * });
  * ```

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -14,7 +14,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.16.14"
     },
     "devDependencies": {
         "@types/node": "^8.0.25",

--- a/sdk/nodejs/sys/dns.ts
+++ b/sdk/nodejs/sys/dns.ts
@@ -17,7 +17,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_ltm_dns_dns1 = new f5bigip.LtmDns("dns1", {
+ * const dns1 = new f5bigip.LtmDns("dns1", {
  *     description: "/Common/DNS1",
  *     nameServers: ["1.1.1.1"],
  *     numberofDots: 2,

--- a/sdk/nodejs/sys/iApp.ts
+++ b/sdk/nodejs/sys/iApp.ts
@@ -15,9 +15,8 @@ import * as utilities from "../utilities";
  * import * as f5bigip from "@pulumi/f5bigip";
  * import * as fs from "fs";
  * 
- * const bigip_sys_iapp_waf_asm = new f5bigip.sys.IApp("waf_asm", {
+ * const wafAsm = new f5bigip.sys.IApp("waf_asm", {
  *     jsonfile: fs.readFileSync("policywaf.json", "utf-8"),
- *     name: "policywaf",
  * });
  * ```
  * 

--- a/sdk/nodejs/sys/ntp.ts
+++ b/sdk/nodejs/sys/ntp.ts
@@ -15,7 +15,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_sys_ntp_ntp1 = new f5bigip.sys.Ntp("ntp1", {
+ * const ntp1 = new f5bigip.sys.Ntp("ntp1", {
  *     description: "/Common/NTP1",
  *     servers: ["time.facebook.com"],
  *     timezone: "America/Los_Angeles",

--- a/sdk/nodejs/sys/provision.ts
+++ b/sdk/nodejs/sys/provision.ts
@@ -13,13 +13,12 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_sys_provision_provision_ilx = new f5bigip.sys.Provision("provision-ilx", {
+ * const provision_ilx = new f5bigip.sys.Provision("provision-ilx", {
  *     cpuRatio: 0,
  *     diskRatio: 0,
  *     fullPath: "ilx",
  *     level: "nominal",
  *     memoryRatio: 0,
- *     name: "/Common/ilx",
  * });
  * ```
  */

--- a/sdk/nodejs/sys/snmp.ts
+++ b/sdk/nodejs/sys/snmp.ts
@@ -13,7 +13,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_sys_snmp_snmp = new f5bigip.sys.Snmp("snmp", {
+ * const snmp = new f5bigip.sys.Snmp("snmp", {
  *     allowedaddresses: ["202.10.10.2"],
  *     sysContact: " NetOPsAdmin s.shitole@f5.com",
  *     sysLocation: "SeattleHQ",

--- a/sdk/nodejs/sys/snmpTraps.ts
+++ b/sdk/nodejs/sys/snmpTraps.ts
@@ -13,11 +13,10 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as f5bigip from "@pulumi/f5bigip";
  * 
- * const bigip_sys_snmp_traps_snmp_traps = new f5bigip.sys.SnmpTraps("snmp_traps", {
+ * const snmpTraps = new f5bigip.sys.SnmpTraps("snmp_traps", {
  *     community: "f5community",
  *     description: "Setup snmp traps",
  *     host: "195.10.10.1",
- *     name: "snmptraps",
  *     port: 111,
  * });
  * ```

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@latest":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.8.tgz#d9a899a2b9b1e29806e9829cce023617bc9f4836"
+"@pulumi/pulumi@^0.16.14":
+  version "0.16.14"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.14.tgz#b8a569a364e46560db0942ac02fe65e3e2288abc"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -22,13 +22,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-    $ npm install @pulumi/f5bigip
+   $ npm install @pulumi/f5bigip
 
 or ``yarn``:
 
 ::
 
-    $ yarn add @pulumi/f5bigip
+   $ yarn add @pulumi/f5bigip
 
 Python
 ~~~~~~
@@ -37,7 +37,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-    $ pip install pulumi_f5bigip
+   $ pip install pulumi_f5bigip
 
 Go
 ~~
@@ -46,7 +46,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-    $ go get github.com/pulumi/pulumi-f5bigip/sdk/go/...
+   $ go get github.com/pulumi/pulumi-f5bigip/sdk/go/...
 
 Reference
 ---------

--- a/sdk/python/pulumi_f5bigip/cm/device.py
+++ b/sdk/python/pulumi_f5bigip/cm/device.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -12,29 +13,35 @@ class Device(pulumi.CustomResource):
     mirror_ip: pulumi.Output[str]
     mirror_secondary_ip: pulumi.Output[str]
     name: pulumi.Output[str]
-    def __init__(__self__, __name__, __opts__=None, configsync_ip=None, mirror_ip=None, mirror_secondary_ip=None, name=None):
+    def __init__(__self__, resource_name, opts=None, configsync_ip=None, mirror_ip=None, mirror_secondary_ip=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_cm_device` provides details about a specific bigip
         
         This resource is helpful when configuring the BIG-IP device in cluster or in HA mode.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] configsync_ip
         :param pulumi.Input[str] mirror_ip
         :param pulumi.Input[str] mirror_secondary_ip
         :param pulumi.Input[str] name
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not configsync_ip:
+        if configsync_ip is None:
             raise TypeError('Missing required property configsync_ip')
         __props__['configsync_ip'] = configsync_ip
 
@@ -42,15 +49,15 @@ class Device(pulumi.CustomResource):
 
         __props__['mirror_secondary_ip'] = mirror_secondary_ip
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(Device, __self__).__init__(
             'f5bigip:cm/device:Device',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/cm/device_group.py
+++ b/sdk/python/pulumi_f5bigip/cm/device_group.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -30,12 +31,12 @@ class DeviceGroup(pulumi.CustomResource):
     """
     Specifies if the device-group will be used for failover or resource syncing
     """
-    def __init__(__self__, __name__, __opts__=None, auto_sync=None, description=None, devices=None, full_load_on_sync=None, incremental_config=None, name=None, network_failover=None, partition=None, save_on_auto_sync=None, type=None):
+    def __init__(__self__, resource_name, opts=None, auto_sync=None, description=None, devices=None, full_load_on_sync=None, incremental_config=None, name=None, network_failover=None, partition=None, save_on_auto_sync=None, type=None, __name__=None, __opts__=None):
         """
         `bigip_cm_devicegroup` A device group is a collection of BIG-IP devices that are configured to securely synchronize their BIG-IP configuration data, and fail over when needed.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] auto_sync: Specifies if the device-group will automatically sync configuration data to its members
         :param pulumi.Input[str] description
         :param pulumi.Input[list] devices: Name of the device to be included in device group, this need to be configured before using devicegroup resource
@@ -47,11 +48,17 @@ class DeviceGroup(pulumi.CustomResource):
         :param pulumi.Input[str] save_on_auto_sync
         :param pulumi.Input[str] type: Specifies if the device-group will be used for failover or resource syncing
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -78,9 +85,9 @@ class DeviceGroup(pulumi.CustomResource):
 
         super(DeviceGroup, __self__).__init__(
             'f5bigip:cm/deviceGroup:DeviceGroup',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/config/vars.py
+++ b/sdk/python/pulumi_f5bigip/config/vars.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables

--- a/sdk/python/pulumi_f5bigip/ltm/data_group.py
+++ b/sdk/python/pulumi_f5bigip/ltm/data_group.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -20,42 +21,48 @@ class DataGroup(pulumi.CustomResource):
     """
     datagroup type (applies to the `name` field of the record), supports: `string`, `ip` or `integer`
     """
-    def __init__(__self__, __name__, __opts__=None, name=None, records=None, type=None):
+    def __init__(__self__, resource_name, opts=None, name=None, records=None, type=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_datagroup` Manages internal (in-line) datagroup configuration
         
         Resource should be named with their "full path". The full path is the combination of the partition + name of the resource, for example /Common/my-datagroup.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] name: , sets the value of the record's `name` attribute, must be of type defined in `type` attribute
         :param pulumi.Input[list] records: a set of `name` and `data` attributes, name must be of type specified by the `type` attributed (`string`, `ip` and `integer`), data is optional and can take any value, multiple `record` sets can be specified as needed.
         :param pulumi.Input[str] type: datagroup type (applies to the `name` field of the record), supports: `string`, `ip` or `integer`
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         __props__['records'] = records
 
-        if not type:
+        if type is None:
             raise TypeError('Missing required property type')
         __props__['type'] = type
 
         super(DataGroup, __self__).__init__(
             'f5bigip:ltm/dataGroup:DataGroup',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/i_rule.py
+++ b/sdk/python/pulumi_f5bigip/ltm/i_rule.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -16,39 +17,45 @@ class IRule(pulumi.CustomResource):
     """
     Name of the iRule
     """
-    def __init__(__self__, __name__, __opts__=None, irule=None, name=None):
+    def __init__(__self__, resource_name, opts=None, irule=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_irule` Creates iRule on BIG-IP F5 device
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] irule: Body of the iRule
         :param pulumi.Input[str] name: Name of the iRule
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not irule:
+        if irule is None:
             raise TypeError('Missing required property irule')
         __props__['irule'] = irule
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(IRule, __self__).__init__(
             'f5bigip:ltm/iRule:IRule',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/monitor.py
+++ b/sdk/python/pulumi_f5bigip/ltm/monitor.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -43,14 +44,14 @@ class Monitor(pulumi.CustomResource):
     Timeout in seconds
     """
     transparent: pulumi.Output[str]
-    def __init__(__self__, __name__, __opts__=None, defaults_from=None, destination=None, interval=None, ip_dscp=None, manual_resume=None, name=None, parent=None, receive=None, receive_disable=None, reverse=None, send=None, time_until_up=None, timeout=None, transparent=None):
+    def __init__(__self__, resource_name, opts=None, defaults_from=None, destination=None, interval=None, ip_dscp=None, manual_resume=None, name=None, parent=None, receive=None, receive_disable=None, reverse=None, send=None, time_until_up=None, timeout=None, transparent=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_monitor` Configures a custom monitor for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] defaults_from
         :param pulumi.Input[str] destination: Specify an alias address for monitoring
         :param pulumi.Input[int] interval: Check interval in seconds
@@ -66,11 +67,17 @@ class Monitor(pulumi.CustomResource):
         :param pulumi.Input[int] timeout: Timeout in seconds
         :param pulumi.Input[str] transparent
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -85,11 +92,11 @@ class Monitor(pulumi.CustomResource):
 
         __props__['manual_resume'] = manual_resume
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
-        if not parent:
+        if parent is None:
             raise TypeError('Missing required property parent')
         __props__['parent'] = parent
 
@@ -109,9 +116,9 @@ class Monitor(pulumi.CustomResource):
 
         super(Monitor, __self__).__init__(
             'f5bigip:ltm/monitor:Monitor',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/node.py
+++ b/sdk/python/pulumi_f5bigip/ltm/node.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -25,14 +26,14 @@ class Node(pulumi.CustomResource):
     """
     Default is "user-up" you can set to "user-down" if you want to disable
     """
-    def __init__(__self__, __name__, __opts__=None, address=None, connection_limit=None, dynamic_ratio=None, fqdns=None, monitor=None, name=None, rate_limit=None, state=None):
+    def __init__(__self__, resource_name, opts=None, address=None, connection_limit=None, dynamic_ratio=None, fqdns=None, monitor=None, name=None, rate_limit=None, state=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_node` Manages a node configuration
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address: IP or hostname of the node
         :param pulumi.Input[int] connection_limit
         :param pulumi.Input[int] dynamic_ratio
@@ -42,16 +43,22 @@ class Node(pulumi.CustomResource):
         :param pulumi.Input[str] rate_limit
         :param pulumi.Input[str] state: Default is "user-up" you can set to "user-down" if you want to disable
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not address:
+        if address is None:
             raise TypeError('Missing required property address')
         __props__['address'] = address
 
@@ -63,7 +70,7 @@ class Node(pulumi.CustomResource):
 
         __props__['monitor'] = monitor
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -73,9 +80,9 @@ class Node(pulumi.CustomResource):
 
         super(Node, __self__).__init__(
             'f5bigip:ltm/node:Node',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/persistence_profile_cookie.py
+++ b/sdk/python/pulumi_f5bigip/ltm/persistence_profile_cookie.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -25,7 +26,7 @@ class PersistenceProfileCookie(pulumi.CustomResource):
     name: pulumi.Output[str]
     override_conn_limit: pulumi.Output[str]
     timeout: pulumi.Output[int]
-    def __init__(__self__, __name__, __opts__=None, always_send=None, app_service=None, cookie_encryption=None, cookie_encryption_passphrase=None, cookie_name=None, defaults_from=None, expiration=None, hash_length=None, hash_offset=None, httponly=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None):
+    def __init__(__self__, resource_name, opts=None, always_send=None, app_service=None, cookie_encryption=None, cookie_encryption_passphrase=None, cookie_name=None, defaults_from=None, expiration=None, hash_length=None, hash_offset=None, httponly=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None, __name__=None, __opts__=None):
         """
         Configures a cookie persistence profile
         
@@ -64,8 +65,8 @@ class PersistenceProfileCookie(pulumi.CustomResource):
         
         `httponly` (Optional) (enabled or disabled) Sending only over http
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] always_send
         :param pulumi.Input[str] app_service
         :param pulumi.Input[str] cookie_encryption
@@ -84,11 +85,17 @@ class PersistenceProfileCookie(pulumi.CustomResource):
         :param pulumi.Input[str] override_conn_limit
         :param pulumi.Input[int] timeout
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -103,7 +110,7 @@ class PersistenceProfileCookie(pulumi.CustomResource):
 
         __props__['cookie_name'] = cookie_name
 
-        if not defaults_from:
+        if defaults_from is None:
             raise TypeError('Missing required property defaults_from')
         __props__['defaults_from'] = defaults_from
 
@@ -123,7 +130,7 @@ class PersistenceProfileCookie(pulumi.CustomResource):
 
         __props__['mirror'] = mirror
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -133,9 +140,9 @@ class PersistenceProfileCookie(pulumi.CustomResource):
 
         super(PersistenceProfileCookie, __self__).__init__(
             'f5bigip:ltm/persistenceProfileCookie:PersistenceProfileCookie',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/persistence_profile_dst_addr.py
+++ b/sdk/python/pulumi_f5bigip/ltm/persistence_profile_dst_addr.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -19,7 +20,7 @@ class PersistenceProfileDstAddr(pulumi.CustomResource):
     name: pulumi.Output[str]
     override_conn_limit: pulumi.Output[str]
     timeout: pulumi.Output[int]
-    def __init__(__self__, __name__, __opts__=None, app_service=None, defaults_from=None, hash_algorithm=None, mask=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None):
+    def __init__(__self__, resource_name, opts=None, app_service=None, defaults_from=None, hash_algorithm=None, mask=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None, __name__=None, __opts__=None):
         """
         Configures a cookie persistence profile
         
@@ -41,8 +42,8 @@ class PersistenceProfileDstAddr(pulumi.CustomResource):
         
         `override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] app_service
         :param pulumi.Input[str] defaults_from
         :param pulumi.Input[str] hash_algorithm
@@ -55,18 +56,24 @@ class PersistenceProfileDstAddr(pulumi.CustomResource):
         :param pulumi.Input[str] override_conn_limit
         :param pulumi.Input[int] timeout
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['app_service'] = app_service
 
-        if not defaults_from:
+        if defaults_from is None:
             raise TypeError('Missing required property defaults_from')
         __props__['defaults_from'] = defaults_from
 
@@ -82,7 +89,7 @@ class PersistenceProfileDstAddr(pulumi.CustomResource):
 
         __props__['mirror'] = mirror
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -92,9 +99,9 @@ class PersistenceProfileDstAddr(pulumi.CustomResource):
 
         super(PersistenceProfileDstAddr, __self__).__init__(
             'f5bigip:ltm/persistenceProfileDstAddr:PersistenceProfileDstAddr',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/persistence_profile_src_addr.py
+++ b/sdk/python/pulumi_f5bigip/ltm/persistence_profile_src_addr.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -20,7 +21,7 @@ class PersistenceProfileSrcAddr(pulumi.CustomResource):
     name: pulumi.Output[str]
     override_conn_limit: pulumi.Output[str]
     timeout: pulumi.Output[int]
-    def __init__(__self__, __name__, __opts__=None, app_service=None, defaults_from=None, hash_algorithm=None, map_proxies=None, mask=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None):
+    def __init__(__self__, resource_name, opts=None, app_service=None, defaults_from=None, hash_algorithm=None, map_proxies=None, mask=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None, __name__=None, __opts__=None):
         """
         Configures a source address persistence profile
         
@@ -48,8 +49,8 @@ class PersistenceProfileSrcAddr(pulumi.CustomResource):
         
         `map_proxies` (Optional) (enabled or disabled) Directs all to the same single pool member
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] app_service
         :param pulumi.Input[str] defaults_from
         :param pulumi.Input[str] hash_algorithm
@@ -63,18 +64,24 @@ class PersistenceProfileSrcAddr(pulumi.CustomResource):
         :param pulumi.Input[str] override_conn_limit
         :param pulumi.Input[int] timeout
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['app_service'] = app_service
 
-        if not defaults_from:
+        if defaults_from is None:
             raise TypeError('Missing required property defaults_from')
         __props__['defaults_from'] = defaults_from
 
@@ -92,7 +99,7 @@ class PersistenceProfileSrcAddr(pulumi.CustomResource):
 
         __props__['mirror'] = mirror
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -102,9 +109,9 @@ class PersistenceProfileSrcAddr(pulumi.CustomResource):
 
         super(PersistenceProfileSrcAddr, __self__).__init__(
             'f5bigip:ltm/persistenceProfileSrcAddr:PersistenceProfileSrcAddr',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/persistence_profile_ssl.py
+++ b/sdk/python/pulumi_f5bigip/ltm/persistence_profile_ssl.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -17,7 +18,7 @@ class PersistenceProfileSsl(pulumi.CustomResource):
     name: pulumi.Output[str]
     override_conn_limit: pulumi.Output[str]
     timeout: pulumi.Output[int]
-    def __init__(__self__, __name__, __opts__=None, app_service=None, defaults_from=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None):
+    def __init__(__self__, resource_name, opts=None, app_service=None, defaults_from=None, match_across_pools=None, match_across_services=None, match_across_virtuals=None, mirror=None, name=None, override_conn_limit=None, timeout=None, __name__=None, __opts__=None):
         """
         Configures an SSL persistence profile
         
@@ -39,8 +40,8 @@ class PersistenceProfileSsl(pulumi.CustomResource):
         
         `override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] app_service
         :param pulumi.Input[str] defaults_from
         :param pulumi.Input[str] match_across_pools
@@ -51,18 +52,24 @@ class PersistenceProfileSsl(pulumi.CustomResource):
         :param pulumi.Input[str] override_conn_limit
         :param pulumi.Input[int] timeout
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['app_service'] = app_service
 
-        if not defaults_from:
+        if defaults_from is None:
             raise TypeError('Missing required property defaults_from')
         __props__['defaults_from'] = defaults_from
 
@@ -74,7 +81,7 @@ class PersistenceProfileSsl(pulumi.CustomResource):
 
         __props__['mirror'] = mirror
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -84,9 +91,9 @@ class PersistenceProfileSsl(pulumi.CustomResource):
 
         super(PersistenceProfileSsl, __self__).__init__(
             'f5bigip:ltm/persistenceProfileSsl:PersistenceProfileSsl',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/policy.py
+++ b/sdk/python/pulumi_f5bigip/ltm/policy.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -29,14 +30,14 @@ class Policy(pulumi.CustomResource):
     """
     Specifies the match strategy
     """
-    def __init__(__self__, __name__, __opts__=None, controls=None, name=None, published_copy=None, requires=None, rules=None, strategy=None):
+    def __init__(__self__, resource_name, opts=None, controls=None, name=None, published_copy=None, requires=None, rules=None, strategy=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_policy` Configures Virtual Server
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] controls: Specifies the controls
         :param pulumi.Input[str] name
         :param pulumi.Input[str] published_copy: If you want to publish the policy else it will be deployed in Drafts mode.
@@ -44,30 +45,36 @@ class Policy(pulumi.CustomResource):
         :param pulumi.Input[list] rules: Rules can be applied using the policy
         :param pulumi.Input[str] strategy: Specifies the match strategy
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not controls:
+        if controls is None:
             raise TypeError('Missing required property controls')
         __props__['controls'] = controls
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         __props__['published_copy'] = published_copy
 
-        if not requires:
+        if requires is None:
             raise TypeError('Missing required property requires')
         __props__['requires'] = requires
 
-        if not rules:
+        if rules is None:
             raise TypeError('Missing required property rules')
         __props__['rules'] = rules
 
@@ -75,9 +82,9 @@ class Policy(pulumi.CustomResource):
 
         super(Policy, __self__).__init__(
             'f5bigip:ltm/policy:Policy',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/pool.py
+++ b/sdk/python/pulumi_f5bigip/ltm/pool.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -22,14 +23,14 @@ class Pool(pulumi.CustomResource):
     reselect_tries: pulumi.Output[int]
     service_down_action: pulumi.Output[str]
     slow_ramp_time: pulumi.Output[int]
-    def __init__(__self__, __name__, __opts__=None, allow_nat=None, allow_snat=None, load_balancing_mode=None, monitors=None, name=None, reselect_tries=None, service_down_action=None, slow_ramp_time=None):
+    def __init__(__self__, resource_name, opts=None, allow_nat=None, allow_snat=None, load_balancing_mode=None, monitors=None, name=None, reselect_tries=None, service_down_action=None, slow_ramp_time=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_pool` Manages a pool configuration.
         
         Resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] allow_nat
         :param pulumi.Input[str] allow_snat
         :param pulumi.Input[str] load_balancing_mode
@@ -39,11 +40,17 @@ class Pool(pulumi.CustomResource):
         :param pulumi.Input[str] service_down_action
         :param pulumi.Input[int] slow_ramp_time
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -56,7 +63,7 @@ class Pool(pulumi.CustomResource):
 
         __props__['monitors'] = monitors
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -68,9 +75,9 @@ class Pool(pulumi.CustomResource):
 
         super(Pool, __self__).__init__(
             'f5bigip:ltm/pool:Pool',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/pool_attachment.py
+++ b/sdk/python/pulumi_f5bigip/ltm/pool_attachment.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -16,39 +17,45 @@ class PoolAttachment(pulumi.CustomResource):
     """
     Name of the pool in /Partition/Name format
     """
-    def __init__(__self__, __name__, __opts__=None, node=None, pool=None):
+    def __init__(__self__, resource_name, opts=None, node=None, pool=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_pool_attachment` Manages nodes membership in pools
         
         Resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] node: Node to add to the pool in /Partition/NodeName:Port format (e.g. /Common/Node01:80)
         :param pulumi.Input[str] pool: Name of the pool in /Partition/Name format
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not node:
+        if node is None:
             raise TypeError('Missing required property node')
         __props__['node'] = node
 
-        if not pool:
+        if pool is None:
             raise TypeError('Missing required property pool')
         __props__['pool'] = pool
 
         super(PoolAttachment, __self__).__init__(
             'f5bigip:ltm/poolAttachment:PoolAttachment',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_fast_http.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_fast_http.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -52,14 +53,14 @@ class ProfileFastHttp(pulumi.CustomResource):
     """
     Name of the profile_fasthttp
     """
-    def __init__(__self__, __name__, __opts__=None, connpool_maxreuse=None, connpool_maxsize=None, connpool_minsize=None, connpool_replenish=None, connpool_step=None, connpoolidle_timeoutoverride=None, defaults_from=None, forcehttp10response=None, idle_timeout=None, maxheader_size=None, name=None):
+    def __init__(__self__, resource_name, opts=None, connpool_maxreuse=None, connpool_maxsize=None, connpool_minsize=None, connpool_replenish=None, connpool_step=None, connpoolidle_timeoutoverride=None, defaults_from=None, forcehttp10response=None, idle_timeout=None, maxheader_size=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_fasthttp` Configures a custom profile_fasthttp for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[int] connpool_maxreuse: Specifies the maximum number of times that the system can re-use a current connection. The default value is 0 (zero).
         :param pulumi.Input[int] connpool_maxsize: Specifies the maximum number of connections to a load balancing pool. A setting of 0 specifies that a pool can accept an unlimited number of connections. The default value is 2048.
         :param pulumi.Input[int] connpool_minsize: Specifies the minimum number of connections to a load balancing pool. A setting of 0 specifies that there is no minimum. The default value is 10.
@@ -72,11 +73,17 @@ class ProfileFastHttp(pulumi.CustomResource):
         :param pulumi.Input[int] maxheader_size: Specifies the maximum amount of HTTP header data that the system buffers before making a load balancing decision. The default setting is 32768.
         :param pulumi.Input[str] name: Name of the profile_fasthttp
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -101,15 +108,15 @@ class ProfileFastHttp(pulumi.CustomResource):
 
         __props__['maxheader_size'] = maxheader_size
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(ProfileFastHttp, __self__).__init__(
             'f5bigip:ltm/profileFastHttp:ProfileFastHttp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_fast_l4.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_fast_l4.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -48,14 +49,14 @@ class ProfileFastL4(pulumi.CustomResource):
     """
     Displays the administrative partition within which this profile resides
     """
-    def __init__(__self__, __name__, __opts__=None, client_timeout=None, defaults_from=None, explicitflow_migration=None, hardware_syncookie=None, idle_timeout=None, iptos_toclient=None, iptos_toserver=None, keepalive_interval=None, name=None, partition=None):
+    def __init__(__self__, resource_name, opts=None, client_timeout=None, defaults_from=None, explicitflow_migration=None, hardware_syncookie=None, idle_timeout=None, iptos_toclient=None, iptos_toserver=None, keepalive_interval=None, name=None, partition=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_fastl4` Configures a custom profile_fastl4 for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[int] client_timeout: Specifies late binding client timeout in seconds. This setting specifies the number of seconds allowed for a client to transmit enough data to select a server when late binding is enabled. If it expires timeout-recovery mode will dictate what action to take.
         :param pulumi.Input[str] defaults_from: Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
         :param pulumi.Input[str] explicitflow_migration: Enables or disables late binding explicit flow migration that allows iRules to control when flows move from software to hardware. Explicit flow migration is disabled by default hence BIG-IP automatically migrates flows from software to hardware.
@@ -67,11 +68,17 @@ class ProfileFastL4(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the profile_fastl4
         :param pulumi.Input[str] partition: Displays the administrative partition within which this profile resides
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -92,7 +99,7 @@ class ProfileFastL4(pulumi.CustomResource):
 
         __props__['keepalive_interval'] = keepalive_interval
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -100,9 +107,9 @@ class ProfileFastL4(pulumi.CustomResource):
 
         super(ProfileFastL4, __self__).__init__(
             'f5bigip:ltm/profileFastL4:ProfileFastL4',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_http2.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_http2.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -29,14 +30,14 @@ class ProfileHttp2(pulumi.CustomResource):
     """
     Name of the profile_http2
     """
-    def __init__(__self__, __name__, __opts__=None, activation_modes=None, concurrent_streams_per_connection=None, connection_idle_timeout=None, defaults_from=None, header_table_size=None, name=None):
+    def __init__(__self__, resource_name, opts=None, activation_modes=None, concurrent_streams_per_connection=None, connection_idle_timeout=None, defaults_from=None, header_table_size=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_http2` Configures a custom profile_http2 for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] activation_modes: Specifies what will cause an incoming connection to be handled as a HTTP/2 connection. The default values npn and alpn specify that the TLS next-protocol-negotiation and application-layer-protocol-negotiation extensions will be used.
         :param pulumi.Input[int] concurrent_streams_per_connection: Specifies how many concurrent requests are allowed to be outstanding on a single HTTP/2 connection.
         :param pulumi.Input[int] connection_idle_timeout: Specifies the number of seconds that a connection is idle before the connection is eligible for deletion..
@@ -44,11 +45,17 @@ class ProfileHttp2(pulumi.CustomResource):
         :param pulumi.Input[int] header_table_size
         :param pulumi.Input[str] name: Name of the profile_http2
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -63,15 +70,15 @@ class ProfileHttp2(pulumi.CustomResource):
 
         __props__['header_table_size'] = header_table_size
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(ProfileHttp2, __self__).__init__(
             'f5bigip:ltm/profileHttp2:ProfileHttp2',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_http_compress.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_http_compress.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -24,32 +25,38 @@ class ProfileHttpCompress(pulumi.CustomResource):
     """
     Enables compression on a specified list of HTTP Request-URI responses. Use a regular expression to specify a list of URIs you want to compress.
     """
-    def __init__(__self__, __name__, __opts__=None, defaults_from=None, name=None, uri_excludes=None, uri_includes=None):
+    def __init__(__self__, resource_name, opts=None, defaults_from=None, name=None, uri_excludes=None, uri_includes=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_httpcompress`  Virtual server HTTP compression profile configuration
         
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] defaults_from: Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
         :param pulumi.Input[str] name: Name of the profile_httpcompress
         :param pulumi.Input[list] uri_excludes: Disables compression on a specified list of HTTP Request-URI responses. Use a regular expression to specify a list of URIs you do not want to compress.
         :param pulumi.Input[list] uri_includes: Enables compression on a specified list of HTTP Request-URI responses. Use a regular expression to specify a list of URIs you want to compress.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['defaults_from'] = defaults_from
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -59,9 +66,9 @@ class ProfileHttpCompress(pulumi.CustomResource):
 
         super(ProfileHttpCompress, __self__).__init__(
             'f5bigip:ltm/profileHttpCompress:ProfileHttpCompress',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_one_connect.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_one_connect.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -44,14 +45,14 @@ class ProfileOneConnect(pulumi.CustomResource):
     """
     Specifies a source IP mask. The default value is 0.0.0.0. The system applies the value of this option to the source address to determine its eligibility for reuse. A mask of 0.0.0.0 causes the system to share reused connections across all clients. A host mask (all 1's in binary), causes the system to share only those reused connections originating from the same client IP address.
     """
-    def __init__(__self__, __name__, __opts__=None, defaults_from=None, idle_timeout_override=None, max_age=None, max_reuse=None, max_size=None, name=None, partition=None, share_pools=None, source_mask=None):
+    def __init__(__self__, resource_name, opts=None, defaults_from=None, idle_timeout_override=None, max_age=None, max_reuse=None, max_size=None, name=None, partition=None, share_pools=None, source_mask=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_oneconnect` Configures a custom profile_oneconnect for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] defaults_from: Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
         :param pulumi.Input[str] idle_timeout_override: Specifies the number of seconds that a connection is idle before the connection flow is eligible for deletion. Possible values are disabled, indefinite, or a numeric value that you specify. The default value is disabled.
         :param pulumi.Input[int] max_age: Specifies the maximum age in number of seconds allowed for a connection in the connection reuse pool. For any connection with an age higher than this value, the system removes that connection from the reuse pool. The default value is 86400.
@@ -62,11 +63,17 @@ class ProfileOneConnect(pulumi.CustomResource):
         :param pulumi.Input[str] share_pools: Specify if you want to share the pool, default value is "disabled"
         :param pulumi.Input[str] source_mask: Specifies a source IP mask. The default value is 0.0.0.0. The system applies the value of this option to the source address to determine its eligibility for reuse. A mask of 0.0.0.0 causes the system to share reused connections across all clients. A host mask (all 1's in binary), causes the system to share only those reused connections originating from the same client IP address.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -81,7 +88,7 @@ class ProfileOneConnect(pulumi.CustomResource):
 
         __props__['max_size'] = max_size
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -93,9 +100,9 @@ class ProfileOneConnect(pulumi.CustomResource):
 
         super(ProfileOneConnect, __self__).__init__(
             'f5bigip:ltm/profileOneConnect:ProfileOneConnect',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/profile_tcp.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_tcp.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -48,14 +49,14 @@ class ProfileTcp(pulumi.CustomResource):
     """
     Displays the administrative partition within which this profile resides
     """
-    def __init__(__self__, __name__, __opts__=None, close_wait_timeout=None, defaults_from=None, deferred_accept=None, fast_open=None, finwait2timeout=None, finwait_timeout=None, idle_timeout=None, keepalive_interval=None, name=None, partition=None):
+    def __init__(__self__, resource_name, opts=None, close_wait_timeout=None, defaults_from=None, deferred_accept=None, fast_open=None, finwait2timeout=None, finwait_timeout=None, idle_timeout=None, keepalive_interval=None, name=None, partition=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_profile_tcp` Configures a custom profile_tcp for use by health checks.
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[int] close_wait_timeout: Specifies the number of seconds that a connection remains in a LAST-ACK state before quitting. A value of 0 represents a term of forever (or until the maxrtx of the FIN state). The default value is 5 seconds.
         :param pulumi.Input[str] defaults_from: Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
         :param pulumi.Input[str] deferred_accept: Specifies, when enabled, that the system defers allocation of the connection chain context until the client response is received. This option is useful for dealing with 3-way handshake DOS attacks. The default value is disabled.
@@ -67,11 +68,17 @@ class ProfileTcp(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the profile_tcp
         :param pulumi.Input[str] partition: Displays the administrative partition within which this profile resides
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -92,7 +99,7 @@ class ProfileTcp(pulumi.CustomResource):
 
         __props__['keepalive_interval'] = keepalive_interval
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -100,9 +107,9 @@ class ProfileTcp(pulumi.CustomResource):
 
         super(ProfileTcp, __self__).__init__(
             'f5bigip:ltm/profileTcp:ProfileTcp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/snat.py
+++ b/sdk/python/pulumi_f5bigip/ltm/snat.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -42,14 +43,14 @@ class Snat(pulumi.CustomResource):
     """
     Disables the SNAT on all VLANs.
     """
-    def __init__(__self__, __name__, __opts__=None, autolasthop=None, full_path=None, mirror=None, name=None, origins=None, partition=None, snatpool=None, sourceport=None, translation=None, vlansdisabled=None):
+    def __init__(__self__, resource_name, opts=None, autolasthop=None, full_path=None, mirror=None, name=None, origins=None, partition=None, snatpool=None, sourceport=None, translation=None, vlansdisabled=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_snat` Manages a snat configuration
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] autolasthop
         :param pulumi.Input[str] full_path
         :param pulumi.Input[str] mirror: Enables or disables mirroring of SNAT connections.
@@ -61,11 +62,17 @@ class Snat(pulumi.CustomResource):
         :param pulumi.Input[str] translation: Specifies the name of a translated IP address. Note that translated addresses are outside the traffic management system. You can only use this option when automap and snatpool are not used.
         :param pulumi.Input[bool] vlansdisabled: Disables the SNAT on all VLANs.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -76,11 +83,11 @@ class Snat(pulumi.CustomResource):
 
         __props__['mirror'] = mirror
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
-        if not origins:
+        if origins is None:
             raise TypeError('Missing required property origins')
         __props__['origins'] = origins
 
@@ -96,9 +103,9 @@ class Snat(pulumi.CustomResource):
 
         super(Snat, __self__).__init__(
             'f5bigip:ltm/snat:Snat',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/snat_pool.py
+++ b/sdk/python/pulumi_f5bigip/ltm/snat_pool.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -16,39 +17,45 @@ class SnatPool(pulumi.CustomResource):
     """
     Name of the snatpool
     """
-    def __init__(__self__, __name__, __opts__=None, members=None, name=None):
+    def __init__(__self__, resource_name, opts=None, members=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_snatpool` Collections of SNAT translation addresses
         
         Resource should be named with their "full path". The full path is the combination of the partition + name of the resource, for example /Common/my-snatpool. 
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] members: Specifies a translation address to add to or delete from a SNAT pool (at least one address is required)
         :param pulumi.Input[str] name: Name of the snatpool
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not members:
+        if members is None:
             raise TypeError('Missing required property members')
         __props__['members'] = members
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(SnatPool, __self__).__init__(
             'f5bigip:ltm/snatPool:SnatPool',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/virtual_address.py
+++ b/sdk/python/pulumi_f5bigip/ltm/virtual_address.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -40,14 +41,14 @@ class VirtualAddress(pulumi.CustomResource):
     """
     Specify the partition and traffic group
     """
-    def __init__(__self__, __name__, __opts__=None, advertize_route=None, arp=None, auto_delete=None, conn_limit=None, enabled=None, icmp_echo=None, name=None, traffic_group=None):
+    def __init__(__self__, resource_name, opts=None, advertize_route=None, arp=None, auto_delete=None, conn_limit=None, enabled=None, icmp_echo=None, name=None, traffic_group=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_virtual_address` Configures Virtual Server
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] advertize_route: Enabled dynamic routing of the address
         :param pulumi.Input[bool] arp: Enable or disable ARP for the virtual address
         :param pulumi.Input[bool] auto_delete: Automatically delete the virtual address with the virtual server
@@ -57,11 +58,17 @@ class VirtualAddress(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the virtual address
         :param pulumi.Input[str] traffic_group: Specify the partition and traffic group
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -78,7 +85,7 @@ class VirtualAddress(pulumi.CustomResource):
 
         __props__['icmp_echo'] = icmp_echo
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -86,9 +93,9 @@ class VirtualAddress(pulumi.CustomResource):
 
         super(VirtualAddress, __self__).__init__(
             'f5bigip:ltm/virtualAddress:VirtualAddress',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/ltm/virtual_server.py
+++ b/sdk/python/pulumi_f5bigip/ltm/virtual_server.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -76,14 +77,14 @@ class VirtualServer(pulumi.CustomResource):
     """
     Enables the virtual server on the VLANs specified by the VLANs option.
     """
-    def __init__(__self__, __name__, __opts__=None, client_profiles=None, destination=None, fallback_persistence_profile=None, ip_protocol=None, irules=None, mask=None, name=None, persistence_profiles=None, policies=None, pool=None, port=None, profiles=None, server_profiles=None, snatpool=None, source=None, source_address_translation=None, translate_address=None, translate_port=None, vlans=None, vlans_enabled=None):
+    def __init__(__self__, resource_name, opts=None, client_profiles=None, destination=None, fallback_persistence_profile=None, ip_protocol=None, irules=None, mask=None, name=None, persistence_profiles=None, policies=None, pool=None, port=None, profiles=None, server_profiles=None, snatpool=None, source=None, source_address_translation=None, translate_address=None, translate_port=None, vlans=None, vlans_enabled=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_virtual_server` Configures Virtual Server
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] client_profiles: List of client context profiles associated on the virtual server. Not mutually exclusive with profiles and server_profiles
         :param pulumi.Input[str] destination: Destination IP
         :param pulumi.Input[str] fallback_persistence_profile: Specifies a fallback persistence profile for the Virtual Server to use when the default persistence profile is not available.
@@ -105,18 +106,24 @@ class VirtualServer(pulumi.CustomResource):
         :param pulumi.Input[list] vlans: The virtual server is enabled/disabled on this set of VLANs. See vlans-disabled and vlans-enabled.
         :param pulumi.Input[bool] vlans_enabled: Enables the virtual server on the VLANs specified by the VLANs option.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['client_profiles'] = client_profiles
 
-        if not destination:
+        if destination is None:
             raise TypeError('Missing required property destination')
         __props__['destination'] = destination
 
@@ -128,7 +135,7 @@ class VirtualServer(pulumi.CustomResource):
 
         __props__['mask'] = mask
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -138,7 +145,7 @@ class VirtualServer(pulumi.CustomResource):
 
         __props__['pool'] = pool
 
-        if not port:
+        if port is None:
             raise TypeError('Missing required property port')
         __props__['port'] = port
 
@@ -162,9 +169,9 @@ class VirtualServer(pulumi.CustomResource):
 
         super(VirtualServer, __self__).__init__(
             'f5bigip:ltm/virtualServer:VirtualServer',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/net/route.py
+++ b/sdk/python/pulumi_f5bigip/net/route.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -17,42 +18,48 @@ class Route(pulumi.CustomResource):
     """
     Specifies a gateway address for the route.
     """
-    def __init__(__self__, __name__, __opts__=None, gw=None, name=None, network=None):
+    def __init__(__self__, resource_name, opts=None, gw=None, name=None, network=None, __name__=None, __opts__=None):
         """
         `bigip_net_route` Manages a route configuration
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] gw
         :param pulumi.Input[str] name: Name of the route
         :param pulumi.Input[str] network: Specifies a gateway address for the route.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['gw'] = gw
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
-        if not network:
+        if network is None:
             raise TypeError('Missing required property network')
         __props__['network'] = network
 
         super(Route, __self__).__init__(
             'f5bigip:net/route:Route',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/net/self_ip.py
+++ b/sdk/python/pulumi_f5bigip/net/self_ip.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -24,47 +25,53 @@ class SelfIp(pulumi.CustomResource):
     """
     Specifies the VLAN for which you are setting a self IP address. This setting must be provided when a self IP is created.
     """
-    def __init__(__self__, __name__, __opts__=None, ip=None, name=None, traffic_group=None, vlan=None):
+    def __init__(__self__, resource_name, opts=None, ip=None, name=None, traffic_group=None, vlan=None, __name__=None, __opts__=None):
         """
         `bigip_net_selfip` Manages a selfip configuration
         
         Resource should be named with their "full path". The full path is the combination of the partition + name of the resource, for example /Common/my-selfip.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] ip: The Self IP's address and netmask.
         :param pulumi.Input[str] name: Name of the selfip
         :param pulumi.Input[str] traffic_group: Specifies the traffic group, defaults to `traffic-group-local-only` if not specified.
         :param pulumi.Input[str] vlan: Specifies the VLAN for which you are setting a self IP address. This setting must be provided when a self IP is created.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not ip:
+        if ip is None:
             raise TypeError('Missing required property ip')
         __props__['ip'] = ip
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         __props__['traffic_group'] = traffic_group
 
-        if not vlan:
+        if vlan is None:
             raise TypeError('Missing required property vlan')
         __props__['vlan'] = vlan
 
         super(SelfIp, __self__).__init__(
             'f5bigip:net/selfIp:SelfIp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/net/vlan.py
+++ b/sdk/python/pulumi_f5bigip/net/vlan.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -20,30 +21,36 @@ class Vlan(pulumi.CustomResource):
     """
     Specifies a number that the system adds into the header of any frame passing through the VLAN.
     """
-    def __init__(__self__, __name__, __opts__=None, interfaces=None, name=None, tag=None):
+    def __init__(__self__, resource_name, opts=None, interfaces=None, name=None, tag=None, __name__=None, __opts__=None):
         """
         `bigip_net_vlan` Manages a vlan configuration
         
         For resources should be named with their "full path". The full path is the combination of the partition + name of the resource. For example /Common/my-pool.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] interfaces: Specifies which interfaces you want this VLAN to use for traffic management.
         :param pulumi.Input[str] name: Name of the vlan
         :param pulumi.Input[int] tag: Specifies a number that the system adds into the header of any frame passing through the VLAN.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
         __props__['interfaces'] = interfaces
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
@@ -51,9 +58,9 @@ class Vlan(pulumi.CustomResource):
 
         super(Vlan, __self__).__init__(
             'f5bigip:net/vlan:Vlan',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/provider.py
+++ b/sdk/python/pulumi_f5bigip/provider.py
@@ -3,56 +3,63 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from . import utilities, tables
 
 class Provider(pulumi.ProviderResource):
-    def __init__(__self__, __name__, __opts__=None, address=None, login_ref=None, password=None, token_auth=None, username=None):
+    def __init__(__self__, resource_name, opts=None, address=None, login_ref=None, password=None, token_auth=None, username=None, __name__=None, __opts__=None):
         """
         The provider type for the bigip package. By default, resources use package-wide configuration
         settings, however an explicit `Provider` instance may be created and passed during resource
         construction to achieve fine-grained programmatic control over provider settings. See the
         [documentation](https://pulumi.io/reference/programming-model.html#providers) for more information.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address
         :param pulumi.Input[str] login_ref
         :param pulumi.Input[str] password
         :param pulumi.Input[bool] token_auth
         :param pulumi.Input[str] username
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not address:
+        if address is None:
             raise TypeError('Missing required property address')
         __props__['address'] = address
 
         __props__['login_ref'] = login_ref
 
-        if not password:
+        if password is None:
             raise TypeError('Missing required property password')
         __props__['password'] = password
 
         __props__['token_auth'] = pulumi.Output.from_input(token_auth).apply(json.dumps) if token_auth is not None else None
 
-        if not username:
+        if username is None:
             raise TypeError('Missing required property username')
         __props__['username'] = username
 
         super(Provider, __self__).__init__(
             'f5bigip',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/big_ip_license.py
+++ b/sdk/python/pulumi_f5bigip/sys/big_ip_license.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -10,37 +11,43 @@ from .. import utilities, tables
 class BigIpLicense(pulumi.CustomResource):
     command: pulumi.Output[str]
     registration_key: pulumi.Output[str]
-    def __init__(__self__, __name__, __opts__=None, command=None, registration_key=None):
+    def __init__(__self__, resource_name, opts=None, command=None, registration_key=None, __name__=None, __opts__=None):
         """
         Create a BigIpLicense resource with the given unique name, props, and options.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] command
         :param pulumi.Input[str] registration_key
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not command:
+        if command is None:
             raise TypeError('Missing required property command')
         __props__['command'] = command
 
-        if not registration_key:
+        if registration_key is None:
             raise TypeError('Missing required property registration_key')
         __props__['registration_key'] = registration_key
 
         super(BigIpLicense, __self__).__init__(
             'f5bigip:sys/bigIpLicense:BigIpLicense',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/dns.py
+++ b/sdk/python/pulumi_f5bigip/sys/dns.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -21,27 +22,33 @@ class Dns(pulumi.CustomResource):
     """
     Specify what domains you want to search
     """
-    def __init__(__self__, __name__, __opts__=None, description=None, name_servers=None, number_of_dots=None, searches=None):
+    def __init__(__self__, resource_name, opts=None, description=None, name_servers=None, number_of_dots=None, searches=None, __name__=None, __opts__=None):
         """
         `bigip_ltm_dns` Configures DNS server on F5 BIG-IP
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description
         :param pulumi.Input[list] name_servers: Name or IP address of the DNS server
         :param pulumi.Input[int] number_of_dots: Configures the number of dots needed in a name before an initial absolute query will be made.
         :param pulumi.Input[list] searches: Specify what domains you want to search
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not description:
+        if description is None:
             raise TypeError('Missing required property description')
         __props__['description'] = description
 
@@ -53,9 +60,9 @@ class Dns(pulumi.CustomResource):
 
         super(Dns, __self__).__init__(
             'f5bigip:sys/dns:Dns',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/i_app.py
+++ b/sdk/python/pulumi_f5bigip/sys/i_app.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -31,7 +32,7 @@ class IApp(pulumi.CustomResource):
     template_prerequisite_errors: pulumi.Output[str]
     traffic_group: pulumi.Output[str]
     variables: pulumi.Output[list]
-    def __init__(__self__, __name__, __opts__=None, description=None, devicegroup=None, execute_action=None, inherited_devicegroup=None, inherited_traffic_group=None, jsonfile=None, lists=None, metadatas=None, name=None, partition=None, strict_updates=None, tables=None, template=None, template_modified=None, template_prerequisite_errors=None, traffic_group=None, variables=None):
+    def __init__(__self__, resource_name, opts=None, description=None, devicegroup=None, execute_action=None, inherited_devicegroup=None, inherited_traffic_group=None, jsonfile=None, lists=None, metadatas=None, name=None, partition=None, strict_updates=None, tables=None, template=None, template_modified=None, template_prerequisite_errors=None, traffic_group=None, variables=None, __name__=None, __opts__=None):
         """
         `bigip_sys_iapp` resource helps you to deploy Application Services template that can be used to automate and orchestrate Layer 4-7 applications service deployments using F5 Network. More information on iApp 2.0 is at https://devcentral.f5.com/wiki/iApp.AppSvcsiApp_userguide_userguide.ashx This resource requires a iApp template already imported on BIG-IP, the template can be found at https://github.com/F5Networks/f5-application-services-integration-iApp/releases/download/v2.0.003/appsvcs_integration_v2.0.003.tmpl
         
@@ -497,8 +498,8 @@ class IApp(pulumi.CustomResource):
          * `tables` - Values provided like pool name, nodes etc.
          * `variables` - Name, values, encrypted or not
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description
         :param pulumi.Input[str] devicegroup
         :param pulumi.Input[str] execute_action
@@ -517,11 +518,17 @@ class IApp(pulumi.CustomResource):
         :param pulumi.Input[str] traffic_group
         :param pulumi.Input[list] variables
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -562,9 +569,9 @@ class IApp(pulumi.CustomResource):
 
         super(IApp, __self__).__init__(
             'f5bigip:sys/iApp:IApp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/ntp.py
+++ b/sdk/python/pulumi_f5bigip/sys/ntp.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -17,28 +18,34 @@ class Ntp(pulumi.CustomResource):
     """
     Specifies the time zone that you want to use for the system time.
     """
-    def __init__(__self__, __name__, __opts__=None, description=None, servers=None, timezone=None):
+    def __init__(__self__, resource_name, opts=None, description=None, servers=None, timezone=None, __name__=None, __opts__=None):
         """
         `bigip_sys_ntp` provides details about a specific bigip
         
         This resource is helpful when configuring NTP server on the BIG-IP.
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description
         :param pulumi.Input[list] servers: Adds NTP servers to or deletes NTP servers from the BIG-IP system.
         :param pulumi.Input[str] timezone: Specifies the time zone that you want to use for the system time.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
 
-        if not description:
+        if description is None:
             raise TypeError('Missing required property description')
         __props__['description'] = description
 
@@ -48,9 +55,9 @@ class Ntp(pulumi.CustomResource):
 
         super(Ntp, __self__).__init__(
             'f5bigip:sys/ntp:Ntp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/provision.py
+++ b/sdk/python/pulumi_f5bigip/sys/provision.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -14,12 +15,12 @@ class Provision(pulumi.CustomResource):
     level: pulumi.Output[str]
     memory_ratio: pulumi.Output[int]
     name: pulumi.Output[str]
-    def __init__(__self__, __name__, __opts__=None, cpu_ratio=None, disk_ratio=None, full_path=None, level=None, memory_ratio=None, name=None):
+    def __init__(__self__, resource_name, opts=None, cpu_ratio=None, disk_ratio=None, full_path=None, level=None, memory_ratio=None, name=None, __name__=None, __opts__=None):
         """
         `bigip_sys_provision` provides details bout how to enable "ilx", "asm" "apm" resource on BIG-IP
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[int] cpu_ratio
         :param pulumi.Input[int] disk_ratio
         :param pulumi.Input[str] full_path
@@ -27,11 +28,17 @@ class Provision(pulumi.CustomResource):
         :param pulumi.Input[int] memory_ratio
         :param pulumi.Input[str] name
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -46,15 +53,15 @@ class Provision(pulumi.CustomResource):
 
         __props__['memory_ratio'] = memory_ratio
 
-        if not name:
+        if name is None:
             raise TypeError('Missing required property name')
         __props__['name'] = name
 
         super(Provision, __self__).__init__(
             'f5bigip:sys/provision:Provision',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/snmp.py
+++ b/sdk/python/pulumi_f5bigip/sys/snmp.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -20,21 +21,27 @@ class Snmp(pulumi.CustomResource):
     """
     Describes the system's physical location.
     """
-    def __init__(__self__, __name__, __opts__=None, allowedaddresses=None, sys_contact=None, sys_location=None):
+    def __init__(__self__, resource_name, opts=None, allowedaddresses=None, sys_contact=None, sys_location=None, __name__=None, __opts__=None):
         """
         `bigip_sys_snmp` provides details bout how to enable "ilx", "asm" "apm" resource on BIG-IP
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[list] allowedaddresses: Configures hosts or networks from which snmpd can accept traffic. Entries go directly into hosts.allow.
         :param pulumi.Input[str] sys_contact: Specifies the contact information for the system administrator.
         :param pulumi.Input[str] sys_location: Describes the system's physical location.
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -47,9 +54,9 @@ class Snmp(pulumi.CustomResource):
 
         super(Snmp, __self__).__init__(
             'f5bigip:sys/snmp:Snmp',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/pulumi_f5bigip/sys/snmp_traps.py
+++ b/sdk/python/pulumi_f5bigip/sys/snmp_traps.py
@@ -3,6 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import json
+import warnings
 import pulumi
 import pulumi.runtime
 from .. import utilities, tables
@@ -37,12 +38,12 @@ class SnmpTraps(pulumi.CustomResource):
     security_level: pulumi.Output[str]
     security_name: pulumi.Output[str]
     version: pulumi.Output[str]
-    def __init__(__self__, __name__, __opts__=None, auth_passwordencrypted=None, auth_protocol=None, community=None, description=None, engine_id=None, host=None, name=None, port=None, privacy_password=None, privacy_password_encrypted=None, privacy_protocol=None, security_level=None, security_name=None, version=None):
+    def __init__(__self__, resource_name, opts=None, auth_passwordencrypted=None, auth_protocol=None, community=None, description=None, engine_id=None, host=None, name=None, port=None, privacy_password=None, privacy_password_encrypted=None, privacy_protocol=None, security_level=None, security_name=None, version=None, __name__=None, __opts__=None):
         """
         `bigip_sys_snmp_traps` provides details bout how to enable snmp_traps resource on BIG-IP
         
-        :param str __name__: The name of the resource.
-        :param pulumi.ResourceOptions __opts__: Options for the resource.
+        :param str resource_name: The name of the resource.
+        :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] auth_passwordencrypted
         :param pulumi.Input[str] auth_protocol
         :param pulumi.Input[str] community: Specifies the community string used for this trap.
@@ -58,11 +59,17 @@ class SnmpTraps(pulumi.CustomResource):
         :param pulumi.Input[str] security_name
         :param pulumi.Input[str] version
         """
-        if not __name__:
+        if __name__ is not None:
+            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
+            resource_name = __name__
+        if __opts__ is not None:
+            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
+            opts = __opts__
+        if not resource_name:
             raise TypeError('Missing resource name argument (for URN creation)')
-        if not isinstance(__name__, str):
+        if not isinstance(resource_name, str):
             raise TypeError('Expected resource name to be a string')
-        if __opts__ and not isinstance(__opts__, pulumi.ResourceOptions):
+        if opts and not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
 
         __props__ = dict()
@@ -97,9 +104,9 @@ class SnmpTraps(pulumi.CustomResource):
 
         super(SnmpTraps, __self__).__init__(
             'f5bigip:sys/snmpTraps:SnmpTraps',
-            __name__,
+            resource_name,
             __props__,
-            __opts__)
+            opts)
 
 
     def translate_output_property(self, prop):

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -29,6 +29,6 @@ setup(name='pulumi_f5bigip',
       license='Apache-2.0',
       packages=find_packages(),
       install_requires=[
-          'pulumi>=0.16.0,<0.17.0'
+          'pulumi>=0.16.14,<0.17.0'
       ],
       zip_safe=False)


### PR DESCRIPTION
This updates `pulumi-terraform` and `pulumi` dependencies, the Python and Node.js version constraints, and runs tfgen for the F5 BigIP provider.

A few things we may want to consider:

 - Upstream uses `dep`  for managing dependencies, which we don't have an override tool for. We could consider forking and importing the Dep lock into modules, for which we do have an override tool
- There have been over 100 commits to master since the last upstream release. Do we want to consider basing this on a much later version than the latest release?