### PR TITLE
Manage CHANGELOG with chg(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,27 @@
-## 0.2.3
+CHANGELOG
+=========
 
-## 0.2.2 (Released May 31st, 2019)
+## HEAD (Unreleased)
+_(none)_
 
-- Update to Terraform F5 BigIP provider v0.12.2
+---
 
-## 0.2.1 (Released April 22nd, 2019)
+## 0.2.2 (2019-05-31)
+* Update to v0.12.2 of the Big IP Terraform Provider
 
-- Updated to the latest (unreleased) branch of the Terraform F5 BigIP provider.
+## 0.2.1 (2019-04-22)
+* Update to the latest master branch of the Terraform F5 Big IP provider
 
-### Improvements
+## 0.2.0 (2019-03-06)
+* Update to the latest version of the `pulumi` SDK
 
-## 0.2.0 (Released March 6th, 2019)
+## 0.1.2 (2019-02-20)
+* Add support for the `deleteBeforeReplace` resource option and improved delete-before-replace behaviour introduced in Pulumi v0.16.14
 
-### Improvements
+## 0.1.1 (2019-02-01)
+* Update to v0.12.0 of the Big IP Terraform Provider
+* Add documentation and examples
 
-- Depend on the latest version of `@pulumi/pulumi`.
+## 0.1.0 (2019-02-01)
+* Initial release of F5 Big IP provider
 
-## 0.1.2 (Released February 20th, 2019)
-
-### Improvements
-
-- Support for the `deleteBeforeReplace` resource option and improved
-  delete-before-replace behaviour introduced in [Pulumi
-  0.16.14](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#01614-released-january-31st-2019).
-
-## 0.1.1 (Released February 1st, 2019)
-
-### Improvements
-
-- Lock to `v0.12.0` of the upstream [BigIP LTM](https://github.com/terraform-providers/terraform-provider-bigip/tree/v0.12.0) provider [#4](https://github.com/pulumi/pulumi-f5bigip/pull/4)
--
-- Add documentation and examples [#4](https://github.com/pulumi/pulumi-f5bigip/pull/4)
-
-## 0.1.0 (Released February 1st, 2019)
-
-Initial release!


### PR DESCRIPTION
This commit reformats the CHANGELOG.md file to be in format which can be managed using https://github.com/heff/chg/, in order to make it manageable from scripts.



