### PR TITLE
Upgrade terraform-provider-bigip to v1.22.8

### DIFF
--- a/provider/cmd/pulumi-resource-f5bigip/schema.json
+++ b/provider/cmd/pulumi-resource-f5bigip/schema.json
@@ -88,7 +88,7 @@
             },
             "tokenAuth": {
                 "type": "boolean",
-                "description": "Enable to use an external authentication source (LDAP, TACACS, etc)\n"
+                "description": "Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable\n"
             },
             "tokenTimeout": {
                 "type": "integer",
@@ -1579,23 +1579,23 @@
             "properties": {
                 "cert": {
                     "type": "string",
-                    "description": "Specifies a cert name for use.\n"
+                    "description": "Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`\n"
                 },
                 "chain": {
                     "type": "string",
-                    "description": "Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional\n"
+                    "description": "Specifies a certificate chain file that a server can use for authentication. The default is `None`.\n"
                 },
                 "key": {
                     "type": "string",
-                    "description": "Contains a key name\n"
+                    "description": "Specifies the file name of the SSL key. The default is `default`\n"
                 },
                 "name": {
                     "type": "string",
-                    "description": "Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.\n"
+                    "description": "Name of Cert-key-chain\n"
                 },
                 "passphrase": {
                     "type": "string",
-                    "description": "Key passphrase\n",
+                    "description": "Type the name of the pass phrase used to encrypt the key.\n",
                     "secret": true
                 }
             },
@@ -2869,7 +2869,7 @@
             },
             "tokenAuth": {
                 "type": "boolean",
-                "description": "Enable to use an external authentication source (LDAP, TACACS, etc)\n"
+                "description": "Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable\n"
             },
             "tokenTimeout": {
                 "type": "integer",
@@ -2923,7 +2923,7 @@
             },
             "tokenAuth": {
                 "type": "boolean",
-                "description": "Enable to use an external authentication source (LDAP, TACACS, etc)\n"
+                "description": "Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable\n"
             },
             "tokenTimeout": {
                 "type": "integer",
@@ -9385,7 +9385,7 @@
                 },
                 "cert": {
                     "type": "string",
-                    "description": "Specifies a cert name for use.\n"
+                    "description": "Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`\n"
                 },
                 "certExtensionIncludes": {
                     "type": "array",
@@ -9396,7 +9396,7 @@
                 },
                 "certKeyChain": {
                     "$ref": "#/types/f5bigip:ltm/ProfileClientSslCertKeyChain:ProfileClientSslCertKeyChain",
-                    "deprecationMessage": "This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute."
+                    "description": "`cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.\nSee Cert Key Chain below for more details.\n\n\u003e **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.\n"
                 },
                 "certLifeSpan": {
                     "type": "integer",
@@ -9408,7 +9408,7 @@
                 },
                 "chain": {
                     "type": "string",
-                    "description": "Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional\n"
+                    "description": "Specifies a certificate chain file that a server can use for authentication. The default is `None`.\n"
                 },
                 "cipherGroup": {
                     "type": "string",
@@ -9416,7 +9416,7 @@
                 },
                 "ciphers": {
                     "type": "string",
-                    "description": "Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.\n"
+                    "description": "BigIP Cipher string.\n"
                 },
                 "clientCertCa": {
                     "type": "string",
@@ -9456,7 +9456,7 @@
                 },
                 "key": {
                     "type": "string",
-                    "description": "Contains a key name\n"
+                    "description": "Specifies the file name of the SSL key. The default is `default`\n"
                 },
                 "modSslMethods": {
                     "type": "string",
@@ -9683,7 +9683,7 @@
                 },
                 "cert": {
                     "type": "string",
-                    "description": "Specifies a cert name for use.\n"
+                    "description": "Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`\n"
                 },
                 "certExtensionIncludes": {
                     "type": "array",
@@ -9694,7 +9694,7 @@
                 },
                 "certKeyChain": {
                     "$ref": "#/types/f5bigip:ltm/ProfileClientSslCertKeyChain:ProfileClientSslCertKeyChain",
-                    "deprecationMessage": "This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute."
+                    "description": "`cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.\nSee Cert Key Chain below for more details.\n\n\u003e **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.\n"
                 },
                 "certLifeSpan": {
                     "type": "integer",
@@ -9706,7 +9706,7 @@
                 },
                 "chain": {
                     "type": "string",
-                    "description": "Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional\n"
+                    "description": "Specifies a certificate chain file that a server can use for authentication. The default is `None`.\n"
                 },
                 "cipherGroup": {
                     "type": "string",
@@ -9714,7 +9714,7 @@
                 },
                 "ciphers": {
                     "type": "string",
-                    "description": "Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.\n"
+                    "description": "BigIP Cipher string.\n"
                 },
                 "clientCertCa": {
                     "type": "string",
@@ -9754,7 +9754,7 @@
                 },
                 "key": {
                     "type": "string",
-                    "description": "Contains a key name\n"
+                    "description": "Specifies the file name of the SSL key. The default is `default`\n"
                 },
                 "modSslMethods": {
                     "type": "string",
@@ -9930,7 +9930,7 @@
                     },
                     "cert": {
                         "type": "string",
-                        "description": "Specifies a cert name for use.\n"
+                        "description": "Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`\n"
                     },
                     "certExtensionIncludes": {
                         "type": "array",
@@ -9941,7 +9941,7 @@
                     },
                     "certKeyChain": {
                         "$ref": "#/types/f5bigip:ltm/ProfileClientSslCertKeyChain:ProfileClientSslCertKeyChain",
-                        "deprecationMessage": "This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute."
+                        "description": "`cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.\nSee Cert Key Chain below for more details.\n\n\u003e **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.\n"
                     },
                     "certLifeSpan": {
                         "type": "integer",
@@ -9953,7 +9953,7 @@
                     },
                     "chain": {
                         "type": "string",
-                        "description": "Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional\n"
+                        "description": "Specifies a certificate chain file that a server can use for authentication. The default is `None`.\n"
                     },
                     "cipherGroup": {
                         "type": "string",
@@ -9961,7 +9961,7 @@
                     },
                     "ciphers": {
                         "type": "string",
-                        "description": "Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.\n"
+                        "description": "BigIP Cipher string.\n"
                     },
                     "clientCertCa": {
                         "type": "string",
@@ -10001,7 +10001,7 @@
                     },
                     "key": {
                         "type": "string",
-                        "description": "Contains a key name\n"
+                        "description": "Specifies the file name of the SSL key. The default is `default`\n"
                     },
                     "modSslMethods": {
                         "type": "string",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 toolchain go1.22.7
 
 require (
-	github.com/F5Networks/terraform-provider-bigip v1.22.7
+	github.com/F5Networks/terraform-provider-bigip v1.22.8
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.104.0
 	github.com/pulumi/pulumi/sdk/v3 v3.153.1
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1373,8 +1373,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/F5Networks/terraform-provider-bigip v1.22.7 h1:oDiKdf4J45d6ByeRjTlBPkXUHcrkhPSeq1SqI3m6++Q=
-github.com/F5Networks/terraform-provider-bigip v1.22.7/go.mod h1:V8x6hjXyp0LccbYRTgCcimHx6OwmCCjQlV9V5Yn/xCY=
+github.com/F5Networks/terraform-provider-bigip v1.22.8 h1:s6Pq5cjuDtBC7xxi5U8oLaFS77348kd6JQVmFMTQjrQ=
+github.com/F5Networks/terraform-provider-bigip v1.22.8/go.mod h1:V8x6hjXyp0LccbYRTgCcimHx6OwmCCjQlV9V5Yn/xCY=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.2/go.mod h1:itPGVDKf9cC/ov4MdvJ2QZ0khw4bfoo9jzwTJlaxy2k=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -104,7 +104,7 @@ namespace Pulumi.F5BigIP
 
         private static readonly __Value<bool?> _tokenAuth = new __Value<bool?>(() => __config.GetBoolean("tokenAuth"));
         /// <summary>
-        /// Enable to use an external authentication source (LDAP, TACACS, etc)
+        /// Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         /// </summary>
         public static bool? TokenAuth
         {

--- a/sdk/dotnet/Ltm/Inputs/ProfileClientSslCertKeyChainArgs.cs
+++ b/sdk/dotnet/Ltm/Inputs/ProfileClientSslCertKeyChainArgs.cs
@@ -13,25 +13,25 @@ namespace Pulumi.F5BigIP.Ltm.Inputs
     public sealed class ProfileClientSslCertKeyChainArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         [Input("cert")]
         public Input<string>? Cert { get; set; }
 
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         [Input("chain")]
         public Input<string>? Chain { get; set; }
 
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         [Input("key")]
         public Input<string>? Key { get; set; }
 
         /// <summary>
-        /// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        /// Name of Cert-key-chain
         /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
@@ -40,7 +40,7 @@ namespace Pulumi.F5BigIP.Ltm.Inputs
         private Input<string>? _passphrase;
 
         /// <summary>
-        /// Key passphrase
+        /// Type the name of the pass phrase used to encrypt the key.
         /// </summary>
         public Input<string>? Passphrase
         {

--- a/sdk/dotnet/Ltm/Inputs/ProfileClientSslCertKeyChainGetArgs.cs
+++ b/sdk/dotnet/Ltm/Inputs/ProfileClientSslCertKeyChainGetArgs.cs
@@ -13,25 +13,25 @@ namespace Pulumi.F5BigIP.Ltm.Inputs
     public sealed class ProfileClientSslCertKeyChainGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         [Input("cert")]
         public Input<string>? Cert { get; set; }
 
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         [Input("chain")]
         public Input<string>? Chain { get; set; }
 
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         [Input("key")]
         public Input<string>? Key { get; set; }
 
         /// <summary>
-        /// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        /// Name of Cert-key-chain
         /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
@@ -40,7 +40,7 @@ namespace Pulumi.F5BigIP.Ltm.Inputs
         private Input<string>? _passphrase;
 
         /// <summary>
-        /// Key passphrase
+        /// Type the name of the pass phrase used to encrypt the key.
         /// </summary>
         public Input<string>? Passphrase
         {

--- a/sdk/dotnet/Ltm/Outputs/ProfileClientSslCertKeyChain.cs
+++ b/sdk/dotnet/Ltm/Outputs/ProfileClientSslCertKeyChain.cs
@@ -14,23 +14,23 @@ namespace Pulumi.F5BigIP.Ltm.Outputs
     public sealed class ProfileClientSslCertKeyChain
     {
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         public readonly string? Cert;
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         public readonly string? Chain;
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         public readonly string? Key;
         /// <summary>
-        /// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        /// Name of Cert-key-chain
         /// </summary>
         public readonly string? Name;
         /// <summary>
-        /// Key passphrase
+        /// Type the name of the pass phrase used to encrypt the key.
         /// </summary>
         public readonly string? Passphrase;
 

--- a/sdk/dotnet/Ltm/ProfileClientSsl.cs
+++ b/sdk/dotnet/Ltm/ProfileClientSsl.cs
@@ -114,7 +114,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Output<int> CacheTimeout { get; private set; } = null!;
 
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         [Output("cert")]
         public Output<string> Cert { get; private set; } = null!;
@@ -125,6 +125,12 @@ namespace Pulumi.F5BigIP.Ltm
         [Output("certExtensionIncludes")]
         public Output<ImmutableArray<string>> CertExtensionIncludes { get; private set; } = null!;
 
+        /// <summary>
+        /// `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        /// See Cert Key Chain below for more details.
+        /// 
+        /// &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        /// </summary>
         [Output("certKeyChain")]
         public Output<Outputs.ProfileClientSslCertKeyChain?> CertKeyChain { get; private set; } = null!;
 
@@ -141,7 +147,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Output<string> CertLookupByIpaddrPort { get; private set; } = null!;
 
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         [Output("chain")]
         public Output<string> Chain { get; private set; } = null!;
@@ -153,7 +159,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Output<string> CipherGroup { get; private set; } = null!;
 
         /// <summary>
-        /// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        /// BigIP Cipher string.
         /// </summary>
         [Output("ciphers")]
         public Output<string> Ciphers { get; private set; } = null!;
@@ -213,7 +219,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Output<string> InheritCertKeychain { get; private set; } = null!;
 
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         [Output("key")]
         public Output<string> Key { get; private set; } = null!;
@@ -515,7 +521,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<int>? CacheTimeout { get; set; }
 
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         [Input("cert")]
         public Input<string>? Cert { get; set; }
@@ -532,6 +538,12 @@ namespace Pulumi.F5BigIP.Ltm
             set => _certExtensionIncludes = value;
         }
 
+        /// <summary>
+        /// `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        /// See Cert Key Chain below for more details.
+        /// 
+        /// &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        /// </summary>
         [Input("certKeyChain")]
         public Input<Inputs.ProfileClientSslCertKeyChainArgs>? CertKeyChain { get; set; }
 
@@ -548,7 +560,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? CertLookupByIpaddrPort { get; set; }
 
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         [Input("chain")]
         public Input<string>? Chain { get; set; }
@@ -560,7 +572,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? CipherGroup { get; set; }
 
         /// <summary>
-        /// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        /// BigIP Cipher string.
         /// </summary>
         [Input("ciphers")]
         public Input<string>? Ciphers { get; set; }
@@ -620,7 +632,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? InheritCertKeychain { get; set; }
 
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         [Input("key")]
         public Input<string>? Key { get; set; }
@@ -896,7 +908,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<int>? CacheTimeout { get; set; }
 
         /// <summary>
-        /// Specifies a cert name for use.
+        /// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         /// </summary>
         [Input("cert")]
         public Input<string>? Cert { get; set; }
@@ -913,6 +925,12 @@ namespace Pulumi.F5BigIP.Ltm
             set => _certExtensionIncludes = value;
         }
 
+        /// <summary>
+        /// `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        /// See Cert Key Chain below for more details.
+        /// 
+        /// &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        /// </summary>
         [Input("certKeyChain")]
         public Input<Inputs.ProfileClientSslCertKeyChainGetArgs>? CertKeyChain { get; set; }
 
@@ -929,7 +947,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? CertLookupByIpaddrPort { get; set; }
 
         /// <summary>
-        /// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        /// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         /// </summary>
         [Input("chain")]
         public Input<string>? Chain { get; set; }
@@ -941,7 +959,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? CipherGroup { get; set; }
 
         /// <summary>
-        /// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        /// BigIP Cipher string.
         /// </summary>
         [Input("ciphers")]
         public Input<string>? Ciphers { get; set; }
@@ -1001,7 +1019,7 @@ namespace Pulumi.F5BigIP.Ltm
         public Input<string>? InheritCertKeychain { get; set; }
 
         /// <summary>
-        /// Contains a key name
+        /// Specifies the file name of the SSL key. The default is `default`
         /// </summary>
         [Input("key")]
         public Input<string>? Key { get; set; }

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -131,7 +131,7 @@ namespace Pulumi.F5BigIP
         public Input<bool>? TeemDisable { get; set; }
 
         /// <summary>
-        /// Enable to use an external authentication source (LDAP, TACACS, etc)
+        /// Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         /// </summary>
         [Input("tokenAuth", json: true)]
         public Input<bool>? TokenAuth { get; set; }

--- a/sdk/go/f5bigip/config/config.go
+++ b/sdk/go/f5bigip/config/config.go
@@ -46,7 +46,7 @@ func GetTeemDisable(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "f5bigip:teemDisable")
 }
 
-// Enable to use an external authentication source (LDAP, TACACS, etc)
+// Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
 func GetTokenAuth(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "f5bigip:tokenAuth")
 }

--- a/sdk/go/f5bigip/ltm/profileClientSsl.go
+++ b/sdk/go/f5bigip/ltm/profileClientSsl.go
@@ -78,21 +78,24 @@ type ProfileClientSsl struct {
 	CacheSize pulumi.IntOutput `pulumi:"cacheSize"`
 	// Cache time out
 	CacheTimeout pulumi.IntOutput `pulumi:"cacheTimeout"`
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert pulumi.StringOutput `pulumi:"cert"`
 	// Cert extension includes for ssl forward proxy
 	CertExtensionIncludes pulumi.StringArrayOutput `pulumi:"certExtensionIncludes"`
-	// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+	// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+	// See Cert Key Chain below for more details.
+	//
+	// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 	CertKeyChain ProfileClientSslCertKeyChainPtrOutput `pulumi:"certKeyChain"`
 	// Life span of the certificate in days for ssl forward proxy
 	CertLifeSpan pulumi.IntOutput `pulumi:"certLifeSpan"`
 	// Cert lookup by ip address and port enabled / disabled
 	CertLookupByIpaddrPort pulumi.StringOutput `pulumi:"certLookupByIpaddrPort"`
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain pulumi.StringOutput `pulumi:"chain"`
 	// Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 	CipherGroup pulumi.StringOutput `pulumi:"cipherGroup"`
-	// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+	// BigIP Cipher string.
 	Ciphers pulumi.StringOutput `pulumi:"ciphers"`
 	// (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
 	ClientCertCa pulumi.StringOutput `pulumi:"clientCertCa"`
@@ -112,7 +115,7 @@ type ProfileClientSsl struct {
 	HandshakeTimeout pulumi.StringOutput `pulumi:"handshakeTimeout"`
 	// Inherit cert key chain
 	InheritCertKeychain pulumi.StringOutput `pulumi:"inheritCertKeychain"`
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key pulumi.StringOutput `pulumi:"key"`
 	// ModSSL Methods enabled / disabled. Default is disabled.
 	ModSslMethods pulumi.StringOutput `pulumi:"modSslMethods"`
@@ -242,21 +245,24 @@ type profileClientSslState struct {
 	CacheSize *int `pulumi:"cacheSize"`
 	// Cache time out
 	CacheTimeout *int `pulumi:"cacheTimeout"`
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert *string `pulumi:"cert"`
 	// Cert extension includes for ssl forward proxy
 	CertExtensionIncludes []string `pulumi:"certExtensionIncludes"`
-	// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+	// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+	// See Cert Key Chain below for more details.
+	//
+	// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 	CertKeyChain *ProfileClientSslCertKeyChain `pulumi:"certKeyChain"`
 	// Life span of the certificate in days for ssl forward proxy
 	CertLifeSpan *int `pulumi:"certLifeSpan"`
 	// Cert lookup by ip address and port enabled / disabled
 	CertLookupByIpaddrPort *string `pulumi:"certLookupByIpaddrPort"`
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain *string `pulumi:"chain"`
 	// Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 	CipherGroup *string `pulumi:"cipherGroup"`
-	// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+	// BigIP Cipher string.
 	Ciphers *string `pulumi:"ciphers"`
 	// (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
 	ClientCertCa *string `pulumi:"clientCertCa"`
@@ -276,7 +282,7 @@ type profileClientSslState struct {
 	HandshakeTimeout *string `pulumi:"handshakeTimeout"`
 	// Inherit cert key chain
 	InheritCertKeychain *string `pulumi:"inheritCertKeychain"`
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key *string `pulumi:"key"`
 	// ModSSL Methods enabled / disabled. Default is disabled.
 	ModSslMethods *string `pulumi:"modSslMethods"`
@@ -367,21 +373,24 @@ type ProfileClientSslState struct {
 	CacheSize pulumi.IntPtrInput
 	// Cache time out
 	CacheTimeout pulumi.IntPtrInput
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert pulumi.StringPtrInput
 	// Cert extension includes for ssl forward proxy
 	CertExtensionIncludes pulumi.StringArrayInput
-	// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+	// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+	// See Cert Key Chain below for more details.
+	//
+	// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 	CertKeyChain ProfileClientSslCertKeyChainPtrInput
 	// Life span of the certificate in days for ssl forward proxy
 	CertLifeSpan pulumi.IntPtrInput
 	// Cert lookup by ip address and port enabled / disabled
 	CertLookupByIpaddrPort pulumi.StringPtrInput
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain pulumi.StringPtrInput
 	// Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 	CipherGroup pulumi.StringPtrInput
-	// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+	// BigIP Cipher string.
 	Ciphers pulumi.StringPtrInput
 	// (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
 	ClientCertCa pulumi.StringPtrInput
@@ -401,7 +410,7 @@ type ProfileClientSslState struct {
 	HandshakeTimeout pulumi.StringPtrInput
 	// Inherit cert key chain
 	InheritCertKeychain pulumi.StringPtrInput
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key pulumi.StringPtrInput
 	// ModSSL Methods enabled / disabled. Default is disabled.
 	ModSslMethods pulumi.StringPtrInput
@@ -496,21 +505,24 @@ type profileClientSslArgs struct {
 	CacheSize *int `pulumi:"cacheSize"`
 	// Cache time out
 	CacheTimeout *int `pulumi:"cacheTimeout"`
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert *string `pulumi:"cert"`
 	// Cert extension includes for ssl forward proxy
 	CertExtensionIncludes []string `pulumi:"certExtensionIncludes"`
-	// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+	// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+	// See Cert Key Chain below for more details.
+	//
+	// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 	CertKeyChain *ProfileClientSslCertKeyChain `pulumi:"certKeyChain"`
 	// Life span of the certificate in days for ssl forward proxy
 	CertLifeSpan *int `pulumi:"certLifeSpan"`
 	// Cert lookup by ip address and port enabled / disabled
 	CertLookupByIpaddrPort *string `pulumi:"certLookupByIpaddrPort"`
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain *string `pulumi:"chain"`
 	// Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 	CipherGroup *string `pulumi:"cipherGroup"`
-	// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+	// BigIP Cipher string.
 	Ciphers *string `pulumi:"ciphers"`
 	// (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
 	ClientCertCa *string `pulumi:"clientCertCa"`
@@ -530,7 +542,7 @@ type profileClientSslArgs struct {
 	HandshakeTimeout *string `pulumi:"handshakeTimeout"`
 	// Inherit cert key chain
 	InheritCertKeychain *string `pulumi:"inheritCertKeychain"`
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key *string `pulumi:"key"`
 	// ModSSL Methods enabled / disabled. Default is disabled.
 	ModSslMethods *string `pulumi:"modSslMethods"`
@@ -622,21 +634,24 @@ type ProfileClientSslArgs struct {
 	CacheSize pulumi.IntPtrInput
 	// Cache time out
 	CacheTimeout pulumi.IntPtrInput
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert pulumi.StringPtrInput
 	// Cert extension includes for ssl forward proxy
 	CertExtensionIncludes pulumi.StringArrayInput
-	// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+	// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+	// See Cert Key Chain below for more details.
+	//
+	// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 	CertKeyChain ProfileClientSslCertKeyChainPtrInput
 	// Life span of the certificate in days for ssl forward proxy
 	CertLifeSpan pulumi.IntPtrInput
 	// Cert lookup by ip address and port enabled / disabled
 	CertLookupByIpaddrPort pulumi.StringPtrInput
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain pulumi.StringPtrInput
 	// Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 	CipherGroup pulumi.StringPtrInput
-	// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+	// BigIP Cipher string.
 	Ciphers pulumi.StringPtrInput
 	// (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
 	ClientCertCa pulumi.StringPtrInput
@@ -656,7 +671,7 @@ type ProfileClientSslArgs struct {
 	HandshakeTimeout pulumi.StringPtrInput
 	// Inherit cert key chain
 	InheritCertKeychain pulumi.StringPtrInput
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key pulumi.StringPtrInput
 	// ModSSL Methods enabled / disabled. Default is disabled.
 	ModSslMethods pulumi.StringPtrInput
@@ -866,7 +881,7 @@ func (o ProfileClientSslOutput) CacheTimeout() pulumi.IntOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.IntOutput { return v.CacheTimeout }).(pulumi.IntOutput)
 }
 
-// Specifies a cert name for use.
+// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 func (o ProfileClientSslOutput) Cert() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.Cert }).(pulumi.StringOutput)
 }
@@ -876,7 +891,10 @@ func (o ProfileClientSslOutput) CertExtensionIncludes() pulumi.StringArrayOutput
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringArrayOutput { return v.CertExtensionIncludes }).(pulumi.StringArrayOutput)
 }
 
-// Deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+// `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+// See Cert Key Chain below for more details.
+//
+// > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
 func (o ProfileClientSslOutput) CertKeyChain() ProfileClientSslCertKeyChainPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) ProfileClientSslCertKeyChainPtrOutput { return v.CertKeyChain }).(ProfileClientSslCertKeyChainPtrOutput)
 }
@@ -891,7 +909,7 @@ func (o ProfileClientSslOutput) CertLookupByIpaddrPort() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.CertLookupByIpaddrPort }).(pulumi.StringOutput)
 }
 
-// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 func (o ProfileClientSslOutput) Chain() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.Chain }).(pulumi.StringOutput)
 }
@@ -901,7 +919,7 @@ func (o ProfileClientSslOutput) CipherGroup() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.CipherGroup }).(pulumi.StringOutput)
 }
 
-// Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+// BigIP Cipher string.
 func (o ProfileClientSslOutput) Ciphers() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.Ciphers }).(pulumi.StringOutput)
 }
@@ -951,7 +969,7 @@ func (o ProfileClientSslOutput) InheritCertKeychain() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.InheritCertKeychain }).(pulumi.StringOutput)
 }
 
-// Contains a key name
+// Specifies the file name of the SSL key. The default is `default`
 func (o ProfileClientSslOutput) Key() pulumi.StringOutput {
 	return o.ApplyT(func(v *ProfileClientSsl) pulumi.StringOutput { return v.Key }).(pulumi.StringOutput)
 }

--- a/sdk/go/f5bigip/ltm/pulumiTypes.go
+++ b/sdk/go/f5bigip/ltm/pulumiTypes.go
@@ -1824,15 +1824,15 @@ func (o PolicyRuleConditionArrayOutput) Index(i pulumi.IntInput) PolicyRuleCondi
 }
 
 type ProfileClientSslCertKeyChain struct {
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert *string `pulumi:"cert"`
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain *string `pulumi:"chain"`
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key *string `pulumi:"key"`
-	// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+	// Name of Cert-key-chain
 	Name *string `pulumi:"name"`
-	// Key passphrase
+	// Type the name of the pass phrase used to encrypt the key.
 	Passphrase *string `pulumi:"passphrase"`
 }
 
@@ -1848,15 +1848,15 @@ type ProfileClientSslCertKeyChainInput interface {
 }
 
 type ProfileClientSslCertKeyChainArgs struct {
-	// Specifies a cert name for use.
+	// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 	Cert pulumi.StringPtrInput `pulumi:"cert"`
-	// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+	// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 	Chain pulumi.StringPtrInput `pulumi:"chain"`
-	// Contains a key name
+	// Specifies the file name of the SSL key. The default is `default`
 	Key pulumi.StringPtrInput `pulumi:"key"`
-	// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+	// Name of Cert-key-chain
 	Name pulumi.StringPtrInput `pulumi:"name"`
-	// Key passphrase
+	// Type the name of the pass phrase used to encrypt the key.
 	Passphrase pulumi.StringPtrInput `pulumi:"passphrase"`
 }
 
@@ -1937,27 +1937,27 @@ func (o ProfileClientSslCertKeyChainOutput) ToProfileClientSslCertKeyChainPtrOut
 	}).(ProfileClientSslCertKeyChainPtrOutput)
 }
 
-// Specifies a cert name for use.
+// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 func (o ProfileClientSslCertKeyChainOutput) Cert() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ProfileClientSslCertKeyChain) *string { return v.Cert }).(pulumi.StringPtrOutput)
 }
 
-// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 func (o ProfileClientSslCertKeyChainOutput) Chain() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ProfileClientSslCertKeyChain) *string { return v.Chain }).(pulumi.StringPtrOutput)
 }
 
-// Contains a key name
+// Specifies the file name of the SSL key. The default is `default`
 func (o ProfileClientSslCertKeyChainOutput) Key() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ProfileClientSslCertKeyChain) *string { return v.Key }).(pulumi.StringPtrOutput)
 }
 
-// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+// Name of Cert-key-chain
 func (o ProfileClientSslCertKeyChainOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ProfileClientSslCertKeyChain) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// Key passphrase
+// Type the name of the pass phrase used to encrypt the key.
 func (o ProfileClientSslCertKeyChainOutput) Passphrase() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ProfileClientSslCertKeyChain) *string { return v.Passphrase }).(pulumi.StringPtrOutput)
 }
@@ -1986,7 +1986,7 @@ func (o ProfileClientSslCertKeyChainPtrOutput) Elem() ProfileClientSslCertKeyCha
 	}).(ProfileClientSslCertKeyChainOutput)
 }
 
-// Specifies a cert name for use.
+// Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
 func (o ProfileClientSslCertKeyChainPtrOutput) Cert() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSslCertKeyChain) *string {
 		if v == nil {
@@ -1996,7 +1996,7 @@ func (o ProfileClientSslCertKeyChainPtrOutput) Cert() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+// Specifies a certificate chain file that a server can use for authentication. The default is `None`.
 func (o ProfileClientSslCertKeyChainPtrOutput) Chain() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSslCertKeyChain) *string {
 		if v == nil {
@@ -2006,7 +2006,7 @@ func (o ProfileClientSslCertKeyChainPtrOutput) Chain() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Contains a key name
+// Specifies the file name of the SSL key. The default is `default`
 func (o ProfileClientSslCertKeyChainPtrOutput) Key() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSslCertKeyChain) *string {
 		if v == nil {
@@ -2016,7 +2016,7 @@ func (o ProfileClientSslCertKeyChainPtrOutput) Key() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+// Name of Cert-key-chain
 func (o ProfileClientSslCertKeyChainPtrOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSslCertKeyChain) *string {
 		if v == nil {
@@ -2026,7 +2026,7 @@ func (o ProfileClientSslCertKeyChainPtrOutput) Name() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Key passphrase
+// Type the name of the pass phrase used to encrypt the key.
 func (o ProfileClientSslCertKeyChainPtrOutput) Passphrase() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ProfileClientSslCertKeyChain) *string {
 		if v == nil {

--- a/sdk/go/f5bigip/provider.go
+++ b/sdk/go/f5bigip/provider.go
@@ -65,7 +65,7 @@ type providerArgs struct {
 	Port *string `pulumi:"port"`
 	// If this flag set to true,sending telemetry data to TEEM will be disabled
 	TeemDisable *bool `pulumi:"teemDisable"`
-	// Enable to use an external authentication source (LDAP, TACACS, etc)
+	// Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
 	TokenAuth *bool `pulumi:"tokenAuth"`
 	// A lifespan to request for the AS3 auth token, represented as a number of seconds. Default: 1200
 	TokenTimeout *int `pulumi:"tokenTimeout"`
@@ -95,7 +95,7 @@ type ProviderArgs struct {
 	Port pulumi.StringPtrInput
 	// If this flag set to true,sending telemetry data to TEEM will be disabled
 	TeemDisable pulumi.BoolPtrInput
-	// Enable to use an external authentication source (LDAP, TACACS, etc)
+	// Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
 	TokenAuth pulumi.BoolPtrInput
 	// A lifespan to request for the AS3 auth token, represented as a number of seconds. Default: 1200
 	TokenTimeout pulumi.IntPtrInput

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.pulumi:pulumi:1.0.0")
+    implementation("com.pulumi:pulumi:1.5.0")
 }
 
 task sourcesJar(type: Jar) {

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.pulumi:pulumi:1.5.0")
+    implementation("com.pulumi:pulumi:1.0.0")
 }
 
 task sourcesJar(type: Jar) {

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/Config.java
@@ -62,7 +62,7 @@ public final class Config {
         return Codegen.booleanProp("teemDisable").config(config).get();
     }
 /**
- * Enable to use an external authentication source (LDAP, TACACS, etc)
+ * Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
  * 
  */
     public Optional<Boolean> tokenAuth() {

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ProviderArgs.java
@@ -123,14 +123,14 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Enable to use an external authentication source (LDAP, TACACS, etc)
+     * Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
      * 
      */
     @Import(name="tokenAuth", json=true)
     private @Nullable Output<Boolean> tokenAuth;
 
     /**
-     * @return Enable to use an external authentication source (LDAP, TACACS, etc)
+     * @return Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
      * 
      */
     public Optional<Output<Boolean>> tokenAuth() {
@@ -396,7 +396,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tokenAuth Enable to use an external authentication source (LDAP, TACACS, etc)
+         * @param tokenAuth Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
          * 
          * @return builder
          * 
@@ -407,7 +407,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param tokenAuth Enable to use an external authentication source (LDAP, TACACS, etc)
+         * @param tokenAuth Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/ProfileClientSsl.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/ProfileClientSsl.java
@@ -228,14 +228,14 @@ public class ProfileClientSsl extends com.pulumi.resources.CustomResource {
         return this.cacheTimeout;
     }
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     @Export(name="cert", refs={String.class}, tree="[0]")
     private Output<String> cert;
 
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     public Output<String> cert() {
@@ -256,14 +256,22 @@ public class ProfileClientSsl extends com.pulumi.resources.CustomResource {
         return this.certExtensionIncludes;
     }
     /**
-     * @deprecated
-     * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
      * 
      */
-    @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
     @Export(name="certKeyChain", refs={ProfileClientSslCertKeyChain.class}, tree="[0]")
     private Output</* @Nullable */ ProfileClientSslCertKeyChain> certKeyChain;
 
+    /**
+     * @return `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+     * 
+     */
     public Output<Optional<ProfileClientSslCertKeyChain>> certKeyChain() {
         return Codegen.optional(this.certKeyChain);
     }
@@ -296,14 +304,14 @@ public class ProfileClientSsl extends com.pulumi.resources.CustomResource {
         return this.certLookupByIpaddrPort;
     }
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     @Export(name="chain", refs={String.class}, tree="[0]")
     private Output<String> chain;
 
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     public Output<String> chain() {
@@ -324,14 +332,14 @@ public class ProfileClientSsl extends com.pulumi.resources.CustomResource {
         return this.cipherGroup;
     }
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      * 
      */
     @Export(name="ciphers", refs={String.class}, tree="[0]")
     private Output<String> ciphers;
 
     /**
-     * @return Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * @return BigIP Cipher string.
      * 
      */
     public Output<String> ciphers() {
@@ -464,14 +472,14 @@ public class ProfileClientSsl extends com.pulumi.resources.CustomResource {
         return this.inheritCertKeychain;
     }
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      * 
      */
     @Export(name="key", refs={String.class}, tree="[0]")
     private Output<String> key;
 
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     public Output<String> key() {

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/ProfileClientSslArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/ProfileClientSslArgs.java
@@ -187,14 +187,14 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     @Import(name="cert")
     private @Nullable Output<String> cert;
 
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     public Optional<Output<String>> cert() {
@@ -217,20 +217,22 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * @deprecated
-     * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
      * 
      */
-    @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
     @Import(name="certKeyChain")
     private @Nullable Output<ProfileClientSslCertKeyChainArgs> certKeyChain;
 
     /**
-     * @deprecated
-     * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * @return `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
      * 
      */
-    @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
     public Optional<Output<ProfileClientSslCertKeyChainArgs>> certKeyChain() {
         return Optional.ofNullable(this.certKeyChain);
     }
@@ -266,14 +268,14 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     @Import(name="chain")
     private @Nullable Output<String> chain;
 
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     public Optional<Output<String>> chain() {
@@ -296,14 +298,14 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      * 
      */
     @Import(name="ciphers")
     private @Nullable Output<String> ciphers;
 
     /**
-     * @return Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * @return BigIP Cipher string.
      * 
      */
     public Optional<Output<String>> ciphers() {
@@ -446,14 +448,14 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      * 
      */
     @Import(name="key")
     private @Nullable Output<String> key;
 
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     public Optional<Output<String>> key() {
@@ -1220,7 +1222,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -1231,7 +1233,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -1272,26 +1274,28 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
+         * @param certKeyChain `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+         * See Cert Key Chain below for more details.
+         * 
+         * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+         * 
          * @return builder
          * 
-         * @deprecated
-         * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
-         * 
          */
-        @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
         public Builder certKeyChain(@Nullable Output<ProfileClientSslCertKeyChainArgs> certKeyChain) {
             $.certKeyChain = certKeyChain;
             return this;
         }
 
         /**
+         * @param certKeyChain `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+         * See Cert Key Chain below for more details.
+         * 
+         * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+         * 
          * @return builder
          * 
-         * @deprecated
-         * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
-         * 
          */
-        @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
         public Builder certKeyChain(ProfileClientSslCertKeyChainArgs certKeyChain) {
             return certKeyChain(Output.of(certKeyChain));
         }
@@ -1339,7 +1343,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -1350,7 +1354,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -1381,7 +1385,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param ciphers Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+         * @param ciphers BigIP Cipher string.
          * 
          * @return builder
          * 
@@ -1392,7 +1396,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param ciphers Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+         * @param ciphers BigIP Cipher string.
          * 
          * @return builder
          * 
@@ -1591,7 +1595,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 
@@ -1602,7 +1606,7 @@ public final class ProfileClientSslArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/inputs/ProfileClientSslCertKeyChainArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/inputs/ProfileClientSslCertKeyChainArgs.java
@@ -16,14 +16,14 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
     public static final ProfileClientSslCertKeyChainArgs Empty = new ProfileClientSslCertKeyChainArgs();
 
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     @Import(name="cert")
     private @Nullable Output<String> cert;
 
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     public Optional<Output<String>> cert() {
@@ -31,14 +31,14 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
     }
 
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     @Import(name="chain")
     private @Nullable Output<String> chain;
 
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     public Optional<Output<String>> chain() {
@@ -46,14 +46,14 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
     }
 
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      * 
      */
     @Import(name="key")
     private @Nullable Output<String> key;
 
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     public Optional<Output<String>> key() {
@@ -61,14 +61,14 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
     }
 
     /**
-     * Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+     * Name of Cert-key-chain
      * 
      */
     @Import(name="name")
     private @Nullable Output<String> name;
 
     /**
-     * @return Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+     * @return Name of Cert-key-chain
      * 
      */
     public Optional<Output<String>> name() {
@@ -76,14 +76,14 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
     }
 
     /**
-     * Key passphrase
+     * Type the name of the pass phrase used to encrypt the key.
      * 
      */
     @Import(name="passphrase")
     private @Nullable Output<String> passphrase;
 
     /**
-     * @return Key passphrase
+     * @return Type the name of the pass phrase used to encrypt the key.
      * 
      */
     public Optional<Output<String>> passphrase() {
@@ -119,7 +119,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -130,7 +130,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -140,7 +140,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -151,7 +151,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -161,7 +161,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 
@@ -172,7 +172,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 
@@ -182,7 +182,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param name Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+         * @param name Name of Cert-key-chain
          * 
          * @return builder
          * 
@@ -193,7 +193,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param name Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+         * @param name Name of Cert-key-chain
          * 
          * @return builder
          * 
@@ -203,7 +203,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param passphrase Key passphrase
+         * @param passphrase Type the name of the pass phrase used to encrypt the key.
          * 
          * @return builder
          * 
@@ -214,7 +214,7 @@ public final class ProfileClientSslCertKeyChainArgs extends com.pulumi.resources
         }
 
         /**
-         * @param passphrase Key passphrase
+         * @param passphrase Type the name of the pass phrase used to encrypt the key.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/inputs/ProfileClientSslState.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/inputs/ProfileClientSslState.java
@@ -186,14 +186,14 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
     }
 
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     @Import(name="cert")
     private @Nullable Output<String> cert;
 
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     public Optional<Output<String>> cert() {
@@ -216,20 +216,22 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
     }
 
     /**
-     * @deprecated
-     * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
      * 
      */
-    @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
     @Import(name="certKeyChain")
     private @Nullable Output<ProfileClientSslCertKeyChainArgs> certKeyChain;
 
     /**
-     * @deprecated
-     * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * @return `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     * 
+     * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
      * 
      */
-    @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
     public Optional<Output<ProfileClientSslCertKeyChainArgs>> certKeyChain() {
         return Optional.ofNullable(this.certKeyChain);
     }
@@ -265,14 +267,14 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
     }
 
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     @Import(name="chain")
     private @Nullable Output<String> chain;
 
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     public Optional<Output<String>> chain() {
@@ -295,14 +297,14 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
     }
 
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      * 
      */
     @Import(name="ciphers")
     private @Nullable Output<String> ciphers;
 
     /**
-     * @return Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * @return BigIP Cipher string.
      * 
      */
     public Optional<Output<String>> ciphers() {
@@ -445,14 +447,14 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
     }
 
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      * 
      */
     @Import(name="key")
     private @Nullable Output<String> key;
 
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     public Optional<Output<String>> key() {
@@ -1219,7 +1221,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -1230,7 +1232,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param cert Specifies a cert name for use.
+         * @param cert Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          * 
          * @return builder
          * 
@@ -1271,26 +1273,28 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
+         * @param certKeyChain `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+         * See Cert Key Chain below for more details.
+         * 
+         * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+         * 
          * @return builder
          * 
-         * @deprecated
-         * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
-         * 
          */
-        @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
         public Builder certKeyChain(@Nullable Output<ProfileClientSslCertKeyChainArgs> certKeyChain) {
             $.certKeyChain = certKeyChain;
             return this;
         }
 
         /**
+         * @param certKeyChain `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+         * See Cert Key Chain below for more details.
+         * 
+         * &gt; **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+         * 
          * @return builder
          * 
-         * @deprecated
-         * This Field &#39;cert_key_chain&#39; going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
-         * 
          */
-        @Deprecated /* This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute. */
         public Builder certKeyChain(ProfileClientSslCertKeyChainArgs certKeyChain) {
             return certKeyChain(Output.of(certKeyChain));
         }
@@ -1338,7 +1342,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -1349,7 +1353,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param chain Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * @param chain Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          * 
          * @return builder
          * 
@@ -1380,7 +1384,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param ciphers Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+         * @param ciphers BigIP Cipher string.
          * 
          * @return builder
          * 
@@ -1391,7 +1395,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param ciphers Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+         * @param ciphers BigIP Cipher string.
          * 
          * @return builder
          * 
@@ -1590,7 +1594,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 
@@ -1601,7 +1605,7 @@ public final class ProfileClientSslState extends com.pulumi.resources.ResourceAr
         }
 
         /**
-         * @param key Contains a key name
+         * @param key Specifies the file name of the SSL key. The default is `default`
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/outputs/ProfileClientSslCertKeyChain.java
+++ b/sdk/java/src/main/java/com/pulumi/f5bigip/ltm/outputs/ProfileClientSslCertKeyChain.java
@@ -12,62 +12,62 @@ import javax.annotation.Nullable;
 @CustomType
 public final class ProfileClientSslCertKeyChain {
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     private @Nullable String cert;
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     private @Nullable String chain;
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     private @Nullable String key;
     /**
-     * @return Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+     * @return Name of Cert-key-chain
      * 
      */
     private @Nullable String name;
     /**
-     * @return Key passphrase
+     * @return Type the name of the pass phrase used to encrypt the key.
      * 
      */
     private @Nullable String passphrase;
 
     private ProfileClientSslCertKeyChain() {}
     /**
-     * @return Specifies a cert name for use.
+     * @return Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      * 
      */
     public Optional<String> cert() {
         return Optional.ofNullable(this.cert);
     }
     /**
-     * @return Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * @return Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      * 
      */
     public Optional<String> chain() {
         return Optional.ofNullable(this.chain);
     }
     /**
-     * @return Contains a key name
+     * @return Specifies the file name of the SSL key. The default is `default`
      * 
      */
     public Optional<String> key() {
         return Optional.ofNullable(this.key);
     }
     /**
-     * @return Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+     * @return Name of Cert-key-chain
      * 
      */
     public Optional<String> name() {
         return Optional.ofNullable(this.name);
     }
     /**
-     * @return Key passphrase
+     * @return Type the name of the pass phrase used to encrypt the key.
      * 
      */
     public Optional<String> passphrase() {

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -85,7 +85,7 @@ Object.defineProperty(exports, "teemDisable", {
 });
 
 /**
- * Enable to use an external authentication source (LDAP, TACACS, etc)
+ * Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
  */
 export declare const tokenAuth: boolean | undefined;
 Object.defineProperty(exports, "tokenAuth", {

--- a/sdk/nodejs/ltm/profileClientSsl.ts
+++ b/sdk/nodejs/ltm/profileClientSsl.ts
@@ -107,7 +107,7 @@ export class ProfileClientSsl extends pulumi.CustomResource {
      */
     public readonly cacheTimeout!: pulumi.Output<number>;
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      */
     public readonly cert!: pulumi.Output<string>;
     /**
@@ -115,7 +115,10 @@ export class ProfileClientSsl extends pulumi.CustomResource {
      */
     public readonly certExtensionIncludes!: pulumi.Output<string[]>;
     /**
-     * @deprecated This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     *
+     * > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
      */
     public readonly certKeyChain!: pulumi.Output<outputs.ltm.ProfileClientSslCertKeyChain | undefined>;
     /**
@@ -127,7 +130,7 @@ export class ProfileClientSsl extends pulumi.CustomResource {
      */
     public readonly certLookupByIpaddrPort!: pulumi.Output<string>;
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      */
     public readonly chain!: pulumi.Output<string>;
     /**
@@ -135,7 +138,7 @@ export class ProfileClientSsl extends pulumi.CustomResource {
      */
     public readonly cipherGroup!: pulumi.Output<string>;
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      */
     public readonly ciphers!: pulumi.Output<string>;
     /**
@@ -175,7 +178,7 @@ export class ProfileClientSsl extends pulumi.CustomResource {
      */
     public readonly inheritCertKeychain!: pulumi.Output<string>;
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      */
     public readonly key!: pulumi.Output<string>;
     /**
@@ -492,7 +495,7 @@ export interface ProfileClientSslState {
      */
     cacheTimeout?: pulumi.Input<number>;
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      */
     cert?: pulumi.Input<string>;
     /**
@@ -500,7 +503,10 @@ export interface ProfileClientSslState {
      */
     certExtensionIncludes?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * @deprecated This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     *
+     * > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
      */
     certKeyChain?: pulumi.Input<inputs.ltm.ProfileClientSslCertKeyChain>;
     /**
@@ -512,7 +518,7 @@ export interface ProfileClientSslState {
      */
     certLookupByIpaddrPort?: pulumi.Input<string>;
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      */
     chain?: pulumi.Input<string>;
     /**
@@ -520,7 +526,7 @@ export interface ProfileClientSslState {
      */
     cipherGroup?: pulumi.Input<string>;
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      */
     ciphers?: pulumi.Input<string>;
     /**
@@ -560,7 +566,7 @@ export interface ProfileClientSslState {
      */
     inheritCertKeychain?: pulumi.Input<string>;
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      */
     key?: pulumi.Input<string>;
     /**
@@ -736,7 +742,7 @@ export interface ProfileClientSslArgs {
      */
     cacheTimeout?: pulumi.Input<number>;
     /**
-     * Specifies a cert name for use.
+     * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
      */
     cert?: pulumi.Input<string>;
     /**
@@ -744,7 +750,10 @@ export interface ProfileClientSslArgs {
      */
     certExtensionIncludes?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * @deprecated This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.
+     * `certKeyChain` Specifies one or more certificates and keys to associate with the SSL profile.
+     * See Cert Key Chain below for more details.
+     *
+     * > **NOTE**  `certKeyChain` is recommend way for adding cert-key-chain to profile. If `certKeyChain` block provided, we should not provide `cert`, `key` and `chain`.
      */
     certKeyChain?: pulumi.Input<inputs.ltm.ProfileClientSslCertKeyChain>;
     /**
@@ -756,7 +765,7 @@ export interface ProfileClientSslArgs {
      */
     certLookupByIpaddrPort?: pulumi.Input<string>;
     /**
-     * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+     * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
      */
     chain?: pulumi.Input<string>;
     /**
@@ -764,7 +773,7 @@ export interface ProfileClientSslArgs {
      */
     cipherGroup?: pulumi.Input<string>;
     /**
-     * Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+     * BigIP Cipher string.
      */
     ciphers?: pulumi.Input<string>;
     /**
@@ -804,7 +813,7 @@ export interface ProfileClientSslArgs {
      */
     inheritCertKeychain?: pulumi.Input<string>;
     /**
-     * Contains a key name
+     * Specifies the file name of the SSL key. The default is `default`
      */
     key?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -117,7 +117,7 @@ export interface ProviderArgs {
      */
     teemDisable?: pulumi.Input<boolean>;
     /**
-     * Enable to use an external authentication source (LDAP, TACACS, etc)
+     * Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
      */
     tokenAuth?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1174,23 +1174,23 @@ export namespace ltm {
 
     export interface ProfileClientSslCertKeyChain {
         /**
-         * Specifies a cert name for use.
+         * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          */
         cert?: pulumi.Input<string>;
         /**
-         * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          */
         chain?: pulumi.Input<string>;
         /**
-         * Contains a key name
+         * Specifies the file name of the SSL key. The default is `default`
          */
         key?: pulumi.Input<string>;
         /**
-         * Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+         * Name of Cert-key-chain
          */
         name?: pulumi.Input<string>;
         /**
-         * Key passphrase
+         * Type the name of the pass phrase used to encrypt the key.
          */
         passphrase?: pulumi.Input<string>;
     }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -935,23 +935,23 @@ export namespace ltm {
 
     export interface ProfileClientSslCertKeyChain {
         /**
-         * Specifies a cert name for use.
+         * Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
          */
         cert?: string;
         /**
-         * Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+         * Specifies a certificate chain file that a server can use for authentication. The default is `None`.
          */
         chain?: string;
         /**
-         * Contains a key name
+         * Specifies the file name of the SSL key. The default is `default`
          */
         key?: string;
         /**
-         * Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+         * Name of Cert-key-chain
          */
         name?: string;
         /**
-         * Key passphrase
+         * Type the name of the pass phrase used to encrypt the key.
          */
         passphrase: string;
     }

--- a/sdk/python/pulumi_f5bigip/config/__init__.pyi
+++ b/sdk/python/pulumi_f5bigip/config/__init__.pyi
@@ -51,7 +51,7 @@ If this flag set to true,sending telemetry data to TEEM will be disabled
 
 tokenAuth: Optional[bool]
 """
-Enable to use an external authentication source (LDAP, TACACS, etc)
+Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
 """
 
 tokenTimeout: Optional[int]

--- a/sdk/python/pulumi_f5bigip/config/vars.py
+++ b/sdk/python/pulumi_f5bigip/config/vars.py
@@ -72,7 +72,7 @@ class _ExportableConfig(types.ModuleType):
     @property
     def token_auth(self) -> Optional[bool]:
         """
-        Enable to use an external authentication source (LDAP, TACACS, etc)
+        Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         """
         return __config__.get_bool('tokenAuth')
 

--- a/sdk/python/pulumi_f5bigip/ltm/_inputs.py
+++ b/sdk/python/pulumi_f5bigip/ltm/_inputs.py
@@ -2919,23 +2919,23 @@ if not MYPY:
     class ProfileClientSslCertKeyChainArgsDict(TypedDict):
         cert: NotRequired[pulumi.Input[str]]
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         chain: NotRequired[pulumi.Input[str]]
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         key: NotRequired[pulumi.Input[str]]
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         name: NotRequired[pulumi.Input[str]]
         """
-        Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        Name of Cert-key-chain
         """
         passphrase: NotRequired[pulumi.Input[str]]
         """
-        Key passphrase
+        Type the name of the pass phrase used to encrypt the key.
         """
 elif False:
     ProfileClientSslCertKeyChainArgsDict: TypeAlias = Mapping[str, Any]
@@ -2949,11 +2949,11 @@ class ProfileClientSslCertKeyChainArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  passphrase: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] cert: Specifies a cert name for use.
-        :param pulumi.Input[str] chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
-        :param pulumi.Input[str] key: Contains a key name
-        :param pulumi.Input[str] name: Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
-        :param pulumi.Input[str] passphrase: Key passphrase
+        :param pulumi.Input[str] cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
+        :param pulumi.Input[str] chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
+        :param pulumi.Input[str] key: Specifies the file name of the SSL key. The default is `default`
+        :param pulumi.Input[str] name: Name of Cert-key-chain
+        :param pulumi.Input[str] passphrase: Type the name of the pass phrase used to encrypt the key.
         """
         if cert is not None:
             pulumi.set(__self__, "cert", cert)
@@ -2970,7 +2970,7 @@ class ProfileClientSslCertKeyChainArgs:
     @pulumi.getter
     def cert(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         return pulumi.get(self, "cert")
 
@@ -2982,7 +2982,7 @@ class ProfileClientSslCertKeyChainArgs:
     @pulumi.getter
     def chain(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         return pulumi.get(self, "chain")
 
@@ -2994,7 +2994,7 @@ class ProfileClientSslCertKeyChainArgs:
     @pulumi.getter
     def key(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         return pulumi.get(self, "key")
 
@@ -3006,7 +3006,7 @@ class ProfileClientSslCertKeyChainArgs:
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        Name of Cert-key-chain
         """
         return pulumi.get(self, "name")
 
@@ -3018,7 +3018,7 @@ class ProfileClientSslCertKeyChainArgs:
     @pulumi.getter
     def passphrase(self) -> Optional[pulumi.Input[str]]:
         """
-        Key passphrase
+        Type the name of the pass phrase used to encrypt the key.
         """
         return pulumi.get(self, "passphrase")
 

--- a/sdk/python/pulumi_f5bigip/ltm/outputs.py
+++ b/sdk/python/pulumi_f5bigip/ltm/outputs.py
@@ -2002,11 +2002,11 @@ class ProfileClientSslCertKeyChain(dict):
                  name: Optional[str] = None,
                  passphrase: Optional[str] = None):
         """
-        :param str cert: Specifies a cert name for use.
-        :param str chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
-        :param str key: Contains a key name
-        :param str name: Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
-        :param str passphrase: Key passphrase
+        :param str cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
+        :param str chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
+        :param str key: Specifies the file name of the SSL key. The default is `default`
+        :param str name: Name of Cert-key-chain
+        :param str passphrase: Type the name of the pass phrase used to encrypt the key.
         """
         if cert is not None:
             pulumi.set(__self__, "cert", cert)
@@ -2023,7 +2023,7 @@ class ProfileClientSslCertKeyChain(dict):
     @pulumi.getter
     def cert(self) -> Optional[str]:
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         return pulumi.get(self, "cert")
 
@@ -2031,7 +2031,7 @@ class ProfileClientSslCertKeyChain(dict):
     @pulumi.getter
     def chain(self) -> Optional[str]:
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         return pulumi.get(self, "chain")
 
@@ -2039,7 +2039,7 @@ class ProfileClientSslCertKeyChain(dict):
     @pulumi.getter
     def key(self) -> Optional[str]:
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         return pulumi.get(self, "key")
 
@@ -2047,7 +2047,7 @@ class ProfileClientSslCertKeyChain(dict):
     @pulumi.getter
     def name(self) -> Optional[str]:
         """
-        Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+        Name of Cert-key-chain
         """
         return pulumi.get(self, "name")
 
@@ -2055,7 +2055,7 @@ class ProfileClientSslCertKeyChain(dict):
     @pulumi.getter
     def passphrase(self) -> Optional[str]:
         """
-        Key passphrase
+        Type the name of the pass phrase used to encrypt the key.
         """
         return pulumi.get(self, "passphrase")
 

--- a/sdk/python/pulumi_f5bigip/ltm/profile_client_ssl.py
+++ b/sdk/python/pulumi_f5bigip/ltm/profile_client_ssl.py
@@ -94,13 +94,17 @@ class ProfileClientSslArgs:
         :param pulumi.Input[str] ca_file: (Trusted Certificate Authorities)Specifies a client CA that the system trusts. The default is `None`.
         :param pulumi.Input[int] cache_size: Cache size (sessions).
         :param pulumi.Input[int] cache_timeout: Cache time out
-        :param pulumi.Input[str] cert: Specifies a cert name for use.
+        :param pulumi.Input[str] cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cert_extension_includes: Cert extension includes for ssl forward proxy
+        :param pulumi.Input['ProfileClientSslCertKeyChainArgs'] cert_key_chain: `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+               See Cert Key Chain below for more details.
+               
+               > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
         :param pulumi.Input[int] cert_life_span: Life span of the certificate in days for ssl forward proxy
         :param pulumi.Input[str] cert_lookup_by_ipaddr_port: Cert lookup by ip address and port enabled / disabled
-        :param pulumi.Input[str] chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        :param pulumi.Input[str] chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         :param pulumi.Input[str] cipher_group: Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
-        :param pulumi.Input[str] ciphers: Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        :param pulumi.Input[str] ciphers: BigIP Cipher string.
         :param pulumi.Input[str] client_cert_ca: (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
         :param pulumi.Input[str] crl_file: Specifies the name of a file containing a list of revoked client certificates. The default is `None`.
         :param pulumi.Input[str] defaults_from: Parent profile for this clientssl profile.Once this value has been set, it cannot be changed. Default value is `/Common/clientssl`. It Should Full path `/partition/profile_name`
@@ -110,7 +114,7 @@ class ProfileClientSslArgs:
         :param pulumi.Input[str] generic_alert: Generic alerts enabled / disabled.
         :param pulumi.Input[str] handshake_timeout: Handshake time out (seconds)
         :param pulumi.Input[str] inherit_cert_keychain: Inherit cert key chain
-        :param pulumi.Input[str] key: Contains a key name
+        :param pulumi.Input[str] key: Specifies the file name of the SSL key. The default is `default`
         :param pulumi.Input[str] mod_ssl_methods: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] mode: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] ocsp_stapling: Specifies whether the system uses OCSP stapling. The default value is `disabled`.
@@ -172,9 +176,6 @@ class ProfileClientSslArgs:
             pulumi.set(__self__, "cert", cert)
         if cert_extension_includes is not None:
             pulumi.set(__self__, "cert_extension_includes", cert_extension_includes)
-        if cert_key_chain is not None:
-            warnings.warn("""This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""", DeprecationWarning)
-            pulumi.log.warn("""cert_key_chain is deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""")
         if cert_key_chain is not None:
             pulumi.set(__self__, "cert_key_chain", cert_key_chain)
         if cert_life_span is not None:
@@ -413,7 +414,7 @@ class ProfileClientSslArgs:
     @pulumi.getter
     def cert(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         return pulumi.get(self, "cert")
 
@@ -435,8 +436,13 @@ class ProfileClientSslArgs:
 
     @property
     @pulumi.getter(name="certKeyChain")
-    @_utilities.deprecated("""This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""")
     def cert_key_chain(self) -> Optional[pulumi.Input['ProfileClientSslCertKeyChainArgs']]:
+        """
+        `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        See Cert Key Chain below for more details.
+
+        > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        """
         return pulumi.get(self, "cert_key_chain")
 
     @cert_key_chain.setter
@@ -471,7 +477,7 @@ class ProfileClientSslArgs:
     @pulumi.getter
     def chain(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         return pulumi.get(self, "chain")
 
@@ -495,7 +501,7 @@ class ProfileClientSslArgs:
     @pulumi.getter
     def ciphers(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        BigIP Cipher string.
         """
         return pulumi.get(self, "ciphers")
 
@@ -615,7 +621,7 @@ class ProfileClientSslArgs:
     @pulumi.getter
     def key(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         return pulumi.get(self, "key")
 
@@ -1040,13 +1046,17 @@ class _ProfileClientSslState:
         :param pulumi.Input[str] ca_file: (Trusted Certificate Authorities)Specifies a client CA that the system trusts. The default is `None`.
         :param pulumi.Input[int] cache_size: Cache size (sessions).
         :param pulumi.Input[int] cache_timeout: Cache time out
-        :param pulumi.Input[str] cert: Specifies a cert name for use.
+        :param pulumi.Input[str] cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cert_extension_includes: Cert extension includes for ssl forward proxy
+        :param pulumi.Input['ProfileClientSslCertKeyChainArgs'] cert_key_chain: `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+               See Cert Key Chain below for more details.
+               
+               > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
         :param pulumi.Input[int] cert_life_span: Life span of the certificate in days for ssl forward proxy
         :param pulumi.Input[str] cert_lookup_by_ipaddr_port: Cert lookup by ip address and port enabled / disabled
-        :param pulumi.Input[str] chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        :param pulumi.Input[str] chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         :param pulumi.Input[str] cipher_group: Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
-        :param pulumi.Input[str] ciphers: Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        :param pulumi.Input[str] ciphers: BigIP Cipher string.
         :param pulumi.Input[str] client_cert_ca: (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
         :param pulumi.Input[str] crl_file: Specifies the name of a file containing a list of revoked client certificates. The default is `None`.
         :param pulumi.Input[str] defaults_from: Parent profile for this clientssl profile.Once this value has been set, it cannot be changed. Default value is `/Common/clientssl`. It Should Full path `/partition/profile_name`
@@ -1056,7 +1066,7 @@ class _ProfileClientSslState:
         :param pulumi.Input[str] generic_alert: Generic alerts enabled / disabled.
         :param pulumi.Input[str] handshake_timeout: Handshake time out (seconds)
         :param pulumi.Input[str] inherit_cert_keychain: Inherit cert key chain
-        :param pulumi.Input[str] key: Contains a key name
+        :param pulumi.Input[str] key: Specifies the file name of the SSL key. The default is `default`
         :param pulumi.Input[str] mod_ssl_methods: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] mode: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] name: Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
@@ -1118,9 +1128,6 @@ class _ProfileClientSslState:
             pulumi.set(__self__, "cert", cert)
         if cert_extension_includes is not None:
             pulumi.set(__self__, "cert_extension_includes", cert_extension_includes)
-        if cert_key_chain is not None:
-            warnings.warn("""This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""", DeprecationWarning)
-            pulumi.log.warn("""cert_key_chain is deprecated: This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""")
         if cert_key_chain is not None:
             pulumi.set(__self__, "cert_key_chain", cert_key_chain)
         if cert_life_span is not None:
@@ -1349,7 +1356,7 @@ class _ProfileClientSslState:
     @pulumi.getter
     def cert(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         return pulumi.get(self, "cert")
 
@@ -1371,8 +1378,13 @@ class _ProfileClientSslState:
 
     @property
     @pulumi.getter(name="certKeyChain")
-    @_utilities.deprecated("""This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""")
     def cert_key_chain(self) -> Optional[pulumi.Input['ProfileClientSslCertKeyChainArgs']]:
+        """
+        `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        See Cert Key Chain below for more details.
+
+        > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        """
         return pulumi.get(self, "cert_key_chain")
 
     @cert_key_chain.setter
@@ -1407,7 +1419,7 @@ class _ProfileClientSslState:
     @pulumi.getter
     def chain(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         return pulumi.get(self, "chain")
 
@@ -1431,7 +1443,7 @@ class _ProfileClientSslState:
     @pulumi.getter
     def ciphers(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        BigIP Cipher string.
         """
         return pulumi.get(self, "ciphers")
 
@@ -1551,7 +1563,7 @@ class _ProfileClientSslState:
     @pulumi.getter
     def key(self) -> Optional[pulumi.Input[str]]:
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         return pulumi.get(self, "key")
 
@@ -2017,13 +2029,17 @@ class ProfileClientSsl(pulumi.CustomResource):
         :param pulumi.Input[str] ca_file: (Trusted Certificate Authorities)Specifies a client CA that the system trusts. The default is `None`.
         :param pulumi.Input[int] cache_size: Cache size (sessions).
         :param pulumi.Input[int] cache_timeout: Cache time out
-        :param pulumi.Input[str] cert: Specifies a cert name for use.
+        :param pulumi.Input[str] cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cert_extension_includes: Cert extension includes for ssl forward proxy
+        :param pulumi.Input[Union['ProfileClientSslCertKeyChainArgs', 'ProfileClientSslCertKeyChainArgsDict']] cert_key_chain: `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+               See Cert Key Chain below for more details.
+               
+               > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
         :param pulumi.Input[int] cert_life_span: Life span of the certificate in days for ssl forward proxy
         :param pulumi.Input[str] cert_lookup_by_ipaddr_port: Cert lookup by ip address and port enabled / disabled
-        :param pulumi.Input[str] chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        :param pulumi.Input[str] chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         :param pulumi.Input[str] cipher_group: Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
-        :param pulumi.Input[str] ciphers: Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        :param pulumi.Input[str] ciphers: BigIP Cipher string.
         :param pulumi.Input[str] client_cert_ca: (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
         :param pulumi.Input[str] crl_file: Specifies the name of a file containing a list of revoked client certificates. The default is `None`.
         :param pulumi.Input[str] defaults_from: Parent profile for this clientssl profile.Once this value has been set, it cannot be changed. Default value is `/Common/clientssl`. It Should Full path `/partition/profile_name`
@@ -2033,7 +2049,7 @@ class ProfileClientSsl(pulumi.CustomResource):
         :param pulumi.Input[str] generic_alert: Generic alerts enabled / disabled.
         :param pulumi.Input[str] handshake_timeout: Handshake time out (seconds)
         :param pulumi.Input[str] inherit_cert_keychain: Inherit cert key chain
-        :param pulumi.Input[str] key: Contains a key name
+        :param pulumi.Input[str] key: Specifies the file name of the SSL key. The default is `default`
         :param pulumi.Input[str] mod_ssl_methods: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] mode: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] name: Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
@@ -2332,13 +2348,17 @@ class ProfileClientSsl(pulumi.CustomResource):
         :param pulumi.Input[str] ca_file: (Trusted Certificate Authorities)Specifies a client CA that the system trusts. The default is `None`.
         :param pulumi.Input[int] cache_size: Cache size (sessions).
         :param pulumi.Input[int] cache_timeout: Cache time out
-        :param pulumi.Input[str] cert: Specifies a cert name for use.
+        :param pulumi.Input[str] cert: Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cert_extension_includes: Cert extension includes for ssl forward proxy
+        :param pulumi.Input[Union['ProfileClientSslCertKeyChainArgs', 'ProfileClientSslCertKeyChainArgsDict']] cert_key_chain: `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+               See Cert Key Chain below for more details.
+               
+               > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
         :param pulumi.Input[int] cert_life_span: Life span of the certificate in days for ssl forward proxy
         :param pulumi.Input[str] cert_lookup_by_ipaddr_port: Cert lookup by ip address and port enabled / disabled
-        :param pulumi.Input[str] chain: Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        :param pulumi.Input[str] chain: Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         :param pulumi.Input[str] cipher_group: Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
-        :param pulumi.Input[str] ciphers: Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        :param pulumi.Input[str] ciphers: BigIP Cipher string.
         :param pulumi.Input[str] client_cert_ca: (Advertised Certificate Authorities)Specifies that the CAs that the system advertises to clients is being trusted by the profile. The default is `None`.
         :param pulumi.Input[str] crl_file: Specifies the name of a file containing a list of revoked client certificates. The default is `None`.
         :param pulumi.Input[str] defaults_from: Parent profile for this clientssl profile.Once this value has been set, it cannot be changed. Default value is `/Common/clientssl`. It Should Full path `/partition/profile_name`
@@ -2348,7 +2368,7 @@ class ProfileClientSsl(pulumi.CustomResource):
         :param pulumi.Input[str] generic_alert: Generic alerts enabled / disabled.
         :param pulumi.Input[str] handshake_timeout: Handshake time out (seconds)
         :param pulumi.Input[str] inherit_cert_keychain: Inherit cert key chain
-        :param pulumi.Input[str] key: Contains a key name
+        :param pulumi.Input[str] key: Specifies the file name of the SSL key. The default is `default`
         :param pulumi.Input[str] mod_ssl_methods: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] mode: ModSSL Methods enabled / disabled. Default is disabled.
         :param pulumi.Input[str] name: Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
@@ -2541,7 +2561,7 @@ class ProfileClientSsl(pulumi.CustomResource):
     @pulumi.getter
     def cert(self) -> pulumi.Output[str]:
         """
-        Specifies a cert name for use.
+        Specifies the name of the certificate that the system uses for client-side SSL processing. The default is `default`
         """
         return pulumi.get(self, "cert")
 
@@ -2555,8 +2575,13 @@ class ProfileClientSsl(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="certKeyChain")
-    @_utilities.deprecated("""This Field 'cert_key_chain' going to deprecate in future version, please specify with cert,key,chain,passphrase as separate attribute.""")
     def cert_key_chain(self) -> pulumi.Output[Optional['outputs.ProfileClientSslCertKeyChain']]:
+        """
+        `cert_key_chain` Specifies one or more certificates and keys to associate with the SSL profile.
+        See Cert Key Chain below for more details.
+
+        > **NOTE**  `cert_key_chain` is recommend way for adding cert-key-chain to profile. If `cert_key_chain` block provided, we should not provide `cert`, `key` and `chain`.
+        """
         return pulumi.get(self, "cert_key_chain")
 
     @property
@@ -2579,7 +2604,7 @@ class ProfileClientSsl(pulumi.CustomResource):
     @pulumi.getter
     def chain(self) -> pulumi.Output[str]:
         """
-        Contains a certificate chain that is relevant to the certificate and key mentioned earlier.This key is optional
+        Specifies a certificate chain file that a server can use for authentication. The default is `None`.
         """
         return pulumi.get(self, "chain")
 
@@ -2595,7 +2620,7 @@ class ProfileClientSsl(pulumi.CustomResource):
     @pulumi.getter
     def ciphers(self) -> pulumi.Output[str]:
         """
-        Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
+        BigIP Cipher string.
         """
         return pulumi.get(self, "ciphers")
 
@@ -2675,7 +2700,7 @@ class ProfileClientSsl(pulumi.CustomResource):
     @pulumi.getter
     def key(self) -> pulumi.Output[str]:
         """
-        Contains a key name
+        Specifies the file name of the SSL key. The default is `default`
         """
         return pulumi.get(self, "key")
 

--- a/sdk/python/pulumi_f5bigip/provider.py
+++ b/sdk/python/pulumi_f5bigip/provider.py
@@ -41,7 +41,7 @@ class ProviderArgs:
         :param pulumi.Input[str] password: The user's password. Leave empty if using token_value
         :param pulumi.Input[str] port: Management Port to connect to Bigip
         :param pulumi.Input[bool] teem_disable: If this flag set to true,sending telemetry data to TEEM will be disabled
-        :param pulumi.Input[bool] token_auth: Enable to use an external authentication source (LDAP, TACACS, etc)
+        :param pulumi.Input[bool] token_auth: Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         :param pulumi.Input[int] token_timeout: A lifespan to request for the AS3 auth token, represented as a number of seconds. Default: 1200
         :param pulumi.Input[str] token_value: A token generated outside the provider, in place of password
         :param pulumi.Input[str] trusted_cert_path: Valid Trusted Certificate path
@@ -163,7 +163,7 @@ class ProviderArgs:
     @pulumi.getter(name="tokenAuth")
     def token_auth(self) -> Optional[pulumi.Input[bool]]:
         """
-        Enable to use an external authentication source (LDAP, TACACS, etc)
+        Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         """
         return pulumi.get(self, "token_auth")
 
@@ -266,7 +266,7 @@ class Provider(pulumi.ProviderResource):
         :param pulumi.Input[str] password: The user's password. Leave empty if using token_value
         :param pulumi.Input[str] port: Management Port to connect to Bigip
         :param pulumi.Input[bool] teem_disable: If this flag set to true,sending telemetry data to TEEM will be disabled
-        :param pulumi.Input[bool] token_auth: Enable to use an external authentication source (LDAP, TACACS, etc)
+        :param pulumi.Input[bool] token_auth: Enable to use token authentication. Can be set via the BIGIP_TOKEN_AUTH environment variable
         :param pulumi.Input[int] token_timeout: A lifespan to request for the AS3 auth token, represented as a number of seconds. Default: 1200
         :param pulumi.Input[str] token_value: A token generated outside the provider, in place of password
         :param pulumi.Input[str] trusted_cert_path: Valid Trusted Certificate path


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-f5bigip --kind=provider`.

---

- Upgrading terraform-provider-bigip from 1.22.7  to 1.22.8.
	Fixes #682
